### PR TITLE
update RealSense ROS version from 2.2.21 to 2.2.22

### DIFF
--- a/docker/prebuild/realsense/Dockerfile
+++ b/docker/prebuild/realsense/Dockerfile
@@ -47,7 +47,7 @@ ENV UNDERLAY_WS=/opt/underlay_ws
 RUN mkdir -p $UNDERLAY_WS/src
 WORKDIR $UNDERLAY_WS
 
-ARG REALSENSE_ROS_V=2.2.21
+ARG REALSENSE_ROS_V=2.2.22
 
 # clone realsense-ros source and install dependencies
 RUN cd src && \


### PR DESCRIPTION
This pull request is for solving issue reported in #7.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>