### PR TITLE
Fix launch error of cabot_ui_manager, specify pymongo version as 3.12.2.

### DIFF
--- a/docker/ros1/Dockerfile
+++ b/docker/ros1/Dockerfile
@@ -127,7 +127,7 @@ RUN pip2 install --upgrade pip && \
         future \
 	fastdtw \
 	ibm_watson==3.4.2 \
-	pymongo \
+	pymongo==3.12.2 \
 	pyproj \
 	pyserial \
 	monotonic \


### PR DESCRIPTION
pymongo.son_manipulator is removed from pymongo 4.0.0, but current mongodb_store depends on it. 
To avoid this issue, fix pymongo 3.12.2.

https://pymongo.readthedocs.io/en/stable/changelog.html

https://github.com/strands-project/mongodb_store/blob/0b804c5507463699b5f899b2e2b99543c849d517/mongodb_store/scripts/config_manager.py#L36