### PR TITLE
Fix mapping-related tools

### DIFF
--- a/mf_localization/src/tf2_beacons_listener.py
+++ b/mf_localization/src/tf2_beacons_listener.py
@@ -30,10 +30,19 @@ import tf_conversions
 from std_msgs.msg import String
 
 class BeaconMapper:
-    def __init__(self):
+    def __init__(self, save_empty_beacon_sample, data_inverval=1.2, position_interval=0.5, verbose=False):
+        # parameters
+        self._save_empty_beacon_sample = save_empty_beacon_sample
+        self._data_interval = data_inverval
+        self._position_interval = position_interval
+        self._verbose = verbose
+
+        # variables
         self._current_position = None
         self._fingerprints = []
         self._count = 0
+        self._previous_fingerprint_time = None
+        self._previous_fingerprint_position = None
 
     def beacons_callback(self,message):
         beacons_obj = json.loads(message.data)
@@ -63,22 +72,83 @@ class BeaconMapper:
             }
             self._fingerprints.append(fp_data)
             self._count += 1
+            self._previous_fingerprint_time = rospy.get_time()
+            self._previous_fingerprint_position = t
             print("sampling data count = " + str(self._count) )
 
     def set_current_position(self, position):
         self._current_position = position
 
-if __name__ == "__main__":
+        # create dummy fingerprint data when beacons_callback is not called.
+        if not self._save_empty_beacon_sample:
+            return
+
+        if self._current_position is not None:
+            timestamp = rospy.get_time()
+            t = self._current_position
+
+            # check time interval
+            if self._previous_fingerprint_time is not None:
+                if not self._previous_fingerprint_time + self._data_interval < timestamp:
+                    return
+            else:
+                self._previous_fingerprint_time = timestamp
+                return
+
+            # check position interval
+            if self._previous_fingerprint_position is not None:
+                tp = self._previous_fingerprint_position
+                d2d = ((t.transform.translation.x - tp.transform.translation.x)**2 + (t.transform.translation.y - tp.transform.translation.y)**2)**0.5
+                if d2d < self._position_interval:
+                    return
+
+            fp_data = {
+                "information": {
+                    "x": t.transform.translation.x,
+                    "y": t.transform.translation.y,
+                    "z": t.transform.translation.z,
+                    "tags":[],
+                    "rotation":{
+                        "x": t.transform.rotation.x,
+                        "y": t.transform.rotation.y,
+                        "z": t.transform.rotation.z,
+                        "w": t.transform.rotation.w
+                    }
+                },
+                "data":{
+                    "timestamp": timestamp,
+                    "beacons": [] # empty list
+                }
+            }
+            self._fingerprints.append(fp_data)
+            self._previous_fingerprint_time = timestamp
+            self._previous_fingerprint_position = self._current_position
+            if self._verbose:
+                rospy.loginfo("dummy fingerprint data created at t="+str(timestamp)+", x="+str(t.transform.translation.x)+", y="+str(t.transform.translation.y))
+
+def main():
     rospy.init_node('tf2_beacons_listener')
 
     tfBuffer = tf2_ros.Buffer()
     listener = tf2_ros.TransformListener(tfBuffer)
 
+    # parameters
     sub_topics_str = rospy.get_param("~topics", "['/wireless/beacons','/wireless/wifi']")
+    output = rospy.get_param("~output")
+    verbose = rospy.get_param("~verbose", False)
+
+    save_empty_beacon_sample = rospy.get_param("~save_empty_beacon_sample", False)
+    fingerprint_data_interval = rospy.get_param("~fingerprint_data_interval", 1.2) # should be larger than 1.0 s because beacon data interval is about 1.0 s.
+    fingerprint_position_interval = rospy.get_param("~fingerprint_position_interval", 0.5) # to prevent the mapper from creating dummy fingerprint data at the same position
+
     import ast
     sub_topics = ast.literal_eval(sub_topics_str)
 
-    mapper = BeaconMapper()
+    mapper = BeaconMapper(save_empty_beacon_sample=save_empty_beacon_sample,
+                            data_inverval=fingerprint_data_interval,
+                            position_interval=fingerprint_position_interval,
+                            verbose=verbose
+                            )
     #beacons_sub = rospy.Subscriber("/wireless/beacons", String, mapper.beacons_callback)
     #wifi_sub = rospy.Subscriber("/wireless/wifi", String, mapper.beacons_callback)
     subscribers = []
@@ -88,8 +158,6 @@ if __name__ == "__main__":
         subscribers.append(sub)
 
     r = rospy.Rate(100) # 100 Hz
-
-    output = rospy.get_param("~output")
 
     def shutdown_hook():
         if output is not None and 0<len(mapper._fingerprints):
@@ -107,11 +175,8 @@ if __name__ == "__main__":
             rospy.sleep(1.0)
             continue
 
-        #translation = (t.transform.translation.x,
-        #                t.transform.translation.y,
-        #                t.transform.translation.z)
-
-        #print(rostime ,translation)
-
         mapper.set_current_position(t)
         r.sleep()
+
+if __name__ == "__main__":
+    main()

--- a/mf_localization_mapping/launch/demo_2d_VLP16.launch
+++ b/mf_localization_mapping/launch/demo_2d_VLP16.launch
@@ -39,7 +39,7 @@
   <arg name="imu_temp" default="imu_temp/data"/>
   <arg name="points2_temp" default="velodyne_points_temp"/>
 
-  <arg name="configuration_basename" value="cartographer_2d_mapping.lua"/>
+  <arg name="configuration_basename" default="cartographer_2d_mapping.lua"/> <!--  cartographer_2d_mapping.lua or cartographer_2d_mapping_localization.lua  -->
   <arg name="save_state_filename" default="" unless="$(arg save_state)"/>
   <arg name="save_state_filename" default="$(arg bag_filename).pbstream" if="$(arg save_state)"/>
   <arg name="start_trajectory_with_default_topics" default="$(eval load_state_filename=='')"/>
@@ -48,6 +48,9 @@
 
   <arg name="arg_topics" value="--topics /velodyne_packets /$(arg points2) /$(arg scan) /$(arg imu) /beacons /wireless/beacons /wireless/wifi" if="$(arg play_limited_topics)"/>
   <arg name="arg_topics" value="" unless="$(arg play_limited_topics)"/>
+
+  <!-- parameters to tf2_beacons_listener-->
+  <arg name="save_empty_beacon_sample" default="false"/>
 
   <include file="$(find mf_localization_mapping)/launch/cartographer_2d_VLP16.launch">
     <arg name="robot" value="$(arg robot)"/>
@@ -85,6 +88,7 @@
         type="tf2_beacons_listener.py" if="$(arg save_samples)">
     <param name="output" value="$(arg bag_filename).loc.samples.json" />
     <param name="topics" value="$(arg wireless_topics)"/>
+    <param name="save_empty_beacon_sample" value="($ save_empty_beacon_sample)"/>
   </node>
 
 </launch>

--- a/mf_localization_mapping/script/convert_rosbag_for_cartographer.py
+++ b/mf_localization_mapping/script/convert_rosbag_for_cartographer.py
@@ -30,12 +30,18 @@ import rosbag
 
 def main():
     parser = argparse.ArgumentParser("convert imu frame name to 'imu'")
-    parser.add_argument("-i","--input", required=True)
-    parser.add_argument("-o","--output", required=True)
+    parser.add_argument("-i","--input", required=True, help="input bag file")
+    parser.add_argument("-o","--output", required=True, help="output bag file")
+    parser.add_argument("--imu_topic", default="/imu/data")
+    parser.add_argument("--imu_frame", default="imu")
+    parser.add_argument("--fix_imu_timestamp", default=False, action="store_true")
     args = parser.parse_args()
 
     input_bag = args.input
     output_bag = args.output
+    imu_topic = args.imu_topic
+    imu_frame = args.imu_frame
+    fix_imu_timestamp = args.fix_imu_timestamp
 
     if input_bag == output_bag:
         raise RuntimeError("input == output")
@@ -46,11 +52,29 @@ def main():
     with rosbag.Bag(input_bag) as bag:
         for topic, msg, t in bag.read_messages():
 
-            if topic == "/imu/data":
-                msg.header.frame_id = "imu"
+            if topic == imu_topic:
+                # replace imu_frame if necessary
+                if imu_frame != "":
+                    msg.header.frame_id = imu_frame
 
-            if topic in ["/velodyne_points", "/imu/data", "/beacons", "/wireless/beacons", "/wireless/wifi"]:
+                # imu value check
+                ax = msg.linear_acceleration.x
+                ay = msg.linear_acceleration.y
+                az = msg.linear_acceleration.z
+                amp = (ax**2 + ay**2 + az**2)**0.5
+                if amp == 0.0:
+                    print("skipped invalid imu value. (linear_accleration==0)")
+                    continue
+
+            if topic in ["/velodyne_points","/beacons", "/wireless/beacons", "/wireless/wifi"]:
                 outbag.write(topic, msg, t)
+            elif topic ==  imu_topic:
+                # replace imu message timestamps with header timestamps if necessary
+                if fix_imu_timestamp:
+                    outbag.write(topic, msg, msg.header.stamp)
+                else:
+                    outbag.write(topic, msg, t)
+
     outbag.close()
 
 if __name__ == "__main__":

--- a/mf_localization_mapping/urdf/cabot2-gt1.urdf
+++ b/mf_localization_mapping/urdf/cabot2-gt1.urdf
@@ -27,6 +27,7 @@
   <link name="imu" />
   <link name="imu_frame" />
   <link name="imu_frame_xsens" />
+  <link name="imu_link" />
 
   <joint name="velodyne_joint" type="fixed">
     <parent link="base_link" />
@@ -49,6 +50,12 @@
   <joint name="imu_frame_xsens_joint" type="fixed">
     <parent link="imu" />
     <child link="imu_frame_xsens" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+  </joint>
+
+  <joint name="imu_link_joint" type="fixed">
+    <parent link="imu" />
+    <child link="imu_link" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
   </joint>
 


### PR DESCRIPTION
Modified mapping-related tools. This change does not affect the behavior of CaBot.
- made it easy to remove imu messages with invalid acceleration values or timestamp from a bag file by using convert_rosbag_for_cartographer.py 
- tf2_beacon_lister can create sample data with empty beacon lists by adding save_empty_beacon_sample:=true argument to demo_2d_VLP16.launch