### PR TITLE
Fix launch error of cabot_ui, install xterm in ros1 dockerfile

### DIFF
--- a/docker/ros1/Dockerfile
+++ b/docker/ros1/Dockerfile
@@ -58,6 +58,7 @@ RUN apt update && apt install -q -y --no-install-recommends \
 	sox \
 	wget \
 	sysstat \
+	xterm \
 	&& \
 	apt clean && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
When I build docker images after removing all old images, launching xterm from ros1 cabot_ui failed.
I fixed dockerfile for ros1 to solve this.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>