### PR TITLE
Use duration instead of number of frames for tracking and prediction timeout

### DIFF
--- a/track_people_py/scripts/track_abstract_people.py
+++ b/track_people_py/scripts/track_abstract_people.py
@@ -43,7 +43,7 @@ class AbsTrackPeople:
     __metaclass__ = ABCMeta
     
     
-    def __init__(self, device, minimum_valid_track_time_length):
+    def __init__(self, device, minimum_valid_track_duration):
         # settings for visualization
         self.vis_local = False
         self.vis_global = False
@@ -54,7 +54,7 @@ class AbsTrackPeople:
         # start initialization
         rospy.init_node('track_people_py', anonymous=True)
         
-        self.minimum_valid_track_time_length = minimum_valid_track_time_length
+        self.minimum_valid_track_duration = minimum_valid_track_duration
         
         self.device = device
         self.detected_boxes_sub = rospy.Subscriber('track_people_py/detected_boxes', TrackedBoxes, self.detected_boxes_cb)
@@ -79,14 +79,14 @@ class AbsTrackPeople:
         return np.array(detect_results), center_bird_eye_global_list
     
     
-    def pub_result(self, detected_boxes_msg, id_list, color_list, tracked_length):
+    def pub_result(self, detected_boxes_msg, id_list, color_list, tracked_duration):
         # publish tracked boxes message
         tracked_boxes_msg = TrackedBoxes()
         tracked_boxes_msg.header = detected_boxes_msg.header
         tracked_boxes_msg.camera_id = detected_boxes_msg.camera_id
         tracked_boxes_msg.pose = detected_boxes_msg.pose
         for idx_bbox, bbox in enumerate(detected_boxes_msg.tracked_boxes):
-            if tracked_length[idx_bbox] < self.minimum_valid_track_time_length:
+            if tracked_duration[idx_bbox] < self.minimum_valid_track_duration:
                 continue
             tracked_box = TrackedBox()
             tracked_box.header = bbox.header
@@ -100,11 +100,11 @@ class AbsTrackPeople:
         rospy.loginfo("camera ID = " + detected_boxes_msg.camera_id + ", number of tracked people = " + str(len(tracked_boxes_msg.tracked_boxes)))
     
     
-    def vis_result(self, detected_boxes_msg, id_list, color_list, tracked_length):
+    def vis_result(self, detected_boxes_msg, id_list, color_list, tracked_duration):
         # publish visualization marker array for rviz
         marker_array = MarkerArray()
         for idx_bbox, bbox in enumerate(detected_boxes_msg.tracked_boxes):
-            if tracked_length[idx_bbox] < self.minimum_valid_track_time_length:
+            if tracked_duration[idx_bbox] < self.minimum_valid_track_duration:
                 continue
             marker = Marker()
             marker.header = bbox.header
@@ -134,7 +134,7 @@ class AbsTrackPeople:
             plt_y = []
             plt_color = []
             for idx_bbox, bbox in enumerate(detected_boxes_msg.tracked_boxes):
-                if tracked_length[idx_bbox] < self.minimum_valid_track_time_length:
+                if tracked_duration[idx_bbox] < self.minimum_valid_track_duration:
                     continue
                 plt_x.append(bbox.x)
                 plt_y.append(bbox.y)

--- a/track_people_py/scripts/track_sort_3d_people.py
+++ b/track_people_py/scripts/track_sort_3d_people.py
@@ -33,14 +33,14 @@ from track_utils.tracker_sort_3d import TrackerSort3D
 from track_people_py.msg import BoundingBox, TrackedBox, TrackedBoxes
 
 class TrackSort3dPeople(AbsTrackPeople):
-    def __init__(self, device, minimum_valid_track_time_length,
-                 iou_threshold, iou_circle_size, n_frames_inactive_to_remove):
-        AbsTrackPeople.__init__(self, device, minimum_valid_track_time_length)
+    def __init__(self, device, minimum_valid_track_duration,
+                 iou_threshold, iou_circle_size, duration_inactive_to_remove):
+        AbsTrackPeople.__init__(self, device, minimum_valid_track_duration)
         
         # set tracker
         self.tracker = TrackerSort3D(iou_threshold=iou_threshold, iou_circle_size=iou_circle_size,
-                                     n_frames_min_valid_track_length=minimum_valid_track_time_length,
-                                     n_frames_inactive_to_remove=n_frames_inactive_to_remove)
+                                     minimum_valid_track_duration=rospy.Duration(minimum_valid_track_duration),
+                                     duration_inactive_to_remove=rospy.Duration(duration_inactive_to_remove))
 
         self.combined_detected_boxes_pub = rospy.Publisher('track_people_py/combined_detected_boxes', TrackedBoxes, queue_size=10)
 
@@ -83,7 +83,7 @@ class TrackSort3dPeople(AbsTrackPeople):
 
         start_time = time.time()
         try:
-            _, id_list, color_list, tracked_length = self.tracker.track(detect_results, center_bird_eye_global_list, self.frame_id)
+            _, id_list, color_list, tracked_duration = self.tracker.track(detected_boxes_msg.header.stamp, detect_results, center_bird_eye_global_list, self.frame_id)
         except:
             rospy.logerror("tracking error")
             self.processing_detected_boxes = False
@@ -91,9 +91,9 @@ class TrackSort3dPeople(AbsTrackPeople):
         elapsed_time = time.time() - start_time
         # rospy.loginfo("time for tracking :{0}".format(elapsed_time) + "[sec]")
         
-        self.pub_result(combined_msg, id_list, color_list, tracked_length)
+        self.pub_result(combined_msg, id_list, color_list, tracked_duration)
         
-        self.vis_result(combined_msg, id_list, color_list, tracked_length)
+        self.vis_result(combined_msg, id_list, color_list, tracked_duration)
         
         self.frame_id += 1
         # self.prev_detect_time_sec = cur_detect_time_sec
@@ -103,15 +103,15 @@ class TrackSort3dPeople(AbsTrackPeople):
 def main():
     device = "cuda"
     
-    # minimum valid track length should be always 0 for multi camera
-    #minimum_valid_track_time_length = 3 # Minimum time length to consider track is valid
-    minimum_valid_track_time_length = 0 # Minimum time length to consider track is valid
+    # minimum valid duration should be always 0 for multi camera
+    #minimum_valid_track_duration = rospy.Duration(0.3) # Minimum duration to consider track is valid
+    minimum_valid_track_duration = 0 # Minimum duration to consider track is valid
     
     iou_threshold = 0.01 # IOU threshold to consider detection between frames as same person
     iou_circle_size = 1.0 # radius of circle in bird-eye view to calculate IOU
-    n_frames_inactive_to_remove = 30 # number of frames for a track to be inactive before removal
+    duration_inactive_to_remove = 2.0 # duration (seconds) for a track to be inactive before removal
     
-    track_people = TrackSort3dPeople(device, minimum_valid_track_time_length, iou_threshold, iou_circle_size, n_frames_inactive_to_remove)
+    track_people = TrackSort3dPeople(device, minimum_valid_track_duration, iou_threshold, iou_circle_size, duration_inactive_to_remove)
     
     try:
         plt.ion()

--- a/track_people_py/scripts/track_utils/tracker_sort_3d.py
+++ b/track_people_py/scripts/track_utils/tracker_sort_3d.py
@@ -93,7 +93,7 @@ class TrackerSort3D:
         prev_exist = np.zeros(len(bboxes)).astype(np.bool)
         person_id = (-np.ones(len(bboxes))).astype(np.int)
         person_color = [None]*len(bboxes)
-        tracked_duration = np.zeros(len(bboxes)).astype(np.int)
+        tracked_duration = np.zeros(len(bboxes)).astype(np.float)
         
         if (len(bboxes) == 0) and (len(self.box_active) == 0):
             # No new detection and no active tracks


### PR DESCRIPTION
Hi @tatsuya-ishihara 

Tracking/Prediction used numbers of frames to invalidate tracking people, but it could be inconsistent with different frame rates.
So I have changed it to duration in seconds.

Could you please check the fix

- use 2.0 seconds (prev. 60 frames) for prediction timeout
- use 2.0 seconds (prev. 30 frames) for tracking timeout
- use 0.2 seconds (prev. 2 frames) for people publish timeout