### PR TITLE
fix issue "I am reay" announcement is too early

### DIFF
--- a/cabot_ui/package.xml
+++ b/cabot_ui/package.xml
@@ -34,6 +34,7 @@
   <build_depend>rostest</build_depend>
   <build_depend>cabot_msgs</build_depend>
   <build_depend>nav_core</build_depend>
+  <build_depend>mf_localization_msgs</build_depend>
   
   <build_export_depend>rospy</build_export_depend>
   
@@ -41,6 +42,7 @@
   <exec_depend>nav_core</exec_depend>
   <exec_depend>cabot_msgs</exec_depend>
   <exec_depend>mongodb_store</exec_depend>
+  <exec_depend>mf_localization_msgs</exec_depend>
 
   <test_depend>rosunit</test_depend>
   <test_depend>cabot_msgs</test_depend>

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -77,6 +77,7 @@ services:
       - ./cabot_navigation:/home/developer/catkin_ws/src/cabot_navigation
       - ./cabot_ui:/home/developer/catkin_ws/src/cabot_ui
       - ./cabot_ros_backpack:/home/developer/catkin_ws/src/cabot_ros_backpack
+      - ./mf_localization_msgs:/home/developer/catkin_ws/src/mf_localization_msgs
       - ./motor_controller:/home/developer/catkin_ws/src/motor_controller
       - ./cabot_sites:/home/developer/catkin_ws/src/cabot_sites
       - ./script:/home/developer/catkin_ws/script

--- a/mf_localization/src/multi_floor_manager.py
+++ b/mf_localization/src/multi_floor_manager.py
@@ -167,8 +167,7 @@ class MultiFloorManager:
         self.scan_matched_points2_pub = None
         self.resetpose_pub  = rospy.Publisher("resetpose", PoseWithCovarianceStamped, queue_size=10)
         self.global_position_pub = rospy.Publisher("global_position", MFGlobalPosition, queue_size=10)
-        self.localize_status_pub = rospy.Publisher("localize_status", MFLocalizeStatus, queue_size=10)
-        self.set_localize_status(MFLocalizeStatus.UNKNOWN)
+        self.localize_status_pub = rospy.Publisher("localize_status", MFLocalizeStatus, latch=True, queue_size=10)
 
         # Subscriber
         self.scan_matched_points2_sub = None
@@ -1198,6 +1197,7 @@ if __name__ == "__main__":
     # for loginfo
     log_interval = spin_rate # loginfo at about 1 Hz
 
+    multi_floor_manager.set_localize_status(MFLocalizeStatus.UNKNOWN)
     while not rospy.is_shutdown():
         # detect odom movement
         try:

--- a/mf_localization/src/multi_floor_manager.py
+++ b/mf_localization/src/multi_floor_manager.py
@@ -167,6 +167,8 @@ class MultiFloorManager:
         self.scan_matched_points2_pub = None
         self.resetpose_pub  = rospy.Publisher("resetpose", PoseWithCovarianceStamped, queue_size=10)
         self.global_position_pub = rospy.Publisher("global_position", MFGlobalPosition, queue_size=10)
+        self.localize_status_pub = rospy.Publisher("localize_status", MFLocalizeStatus, queue_size=10)
+        self.set_localize_status(MFLocalizeStatus.UNKNOWN)
 
         # Subscriber
         self.scan_matched_points2_sub = None
@@ -180,6 +182,11 @@ class MultiFloorManager:
 
         # for local_map_tf_timer_callback
         self.local_map_tf = None
+
+    def set_localize_status(self, status):
+        msg = MFLocalizeStatus()
+        msg.status = status
+        self.localize_status_pub.publish(msg)
 
     def imu_callback(self, msg):
         # validate imu message
@@ -235,6 +242,9 @@ class MultiFloorManager:
             rospy.loginfo("floor is unknown. Set floor by calling /set_current_floor service before publishing the 2D pose estimate.")
 
         if self.floor is not None and self.mode is not None:
+            if self.mode == LocalizationMode.INIT:
+                self.set_localize_status(MFLocalizeStatus.LOCATING)
+
             # transform pose in the message from map frame to a local frame
             pose_stamped_msg = PoseStamped()
             pose_stamped_msg.header = pose_with_covariance_stamped_msg.header
@@ -326,6 +336,11 @@ class MultiFloorManager:
         if self.scan_matched_points2_sub is not None:
             self.scan_matched_points2_sub.unregister()
         self.scan_matched_points2_sub = rospy.Subscriber(node_id+"/"+str(self.mode)+"/"+"scan_matched_points2", PointCloud2, self.scan_matched_points2_callback)
+
+        if self.mode == LocalizationMode.INIT:
+            self.set_localize_status(MFLocalizeStatus.LOCATING)
+        if self.mode == LocalizationMode.TRACK:
+            self.set_localize_status(MFLocalizeStatus.TRACKING)
 
     # simple failure detection based on the root mean square error between tracked and estimated locations
     def check_localization_failure(self, loc_track, loc_est):
@@ -735,6 +750,7 @@ class MultiFloorManager:
         self.valid_points2 = False
 
         tfBuffer.clear() # clear buffered tf added by finished trajectories
+        self.set_localize_status(MFLocalizeStatus.UNKNOWN)
 
     def restart_localization(self):
         self.is_active = False

--- a/mf_localization_msgs/CMakeLists.txt
+++ b/mf_localization_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ add_message_files(
     StatusResponse.msg
     MFGlobalPosition.msg
     MFLocalPosition.msg
+    MFLocalizeStatus.msg
  )
 
 ## Generate services in the 'srv' folder

--- a/mf_localization_msgs/msg/MFLocalizeStatus.msg
+++ b/mf_localization_msgs/msg/MFLocalizeStatus.msg
@@ -1,0 +1,40 @@
+# Copyright (c) 2022  IBM Corporation and Carnegie Mellon University
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# localization monitoring status transition
+#                                 ┌─────┐               ┌─────┐
+#                                 │     │               │     │
+#        ┌────────────┐       ┌───V─────┴──┐        ┌───V─────┴──┐       ┌────────────┐
+#        │            <───────┤            │        │            <───────┤            │
+#        │  UNKNOWN   │       │  LOCATING  │        │  TRACKING  │       │ UNRELIABLE │
+# ───────>            │       │            ├────────>            │       │            │
+#        │            ├───────>            │        │            ├───────>            │
+#        └──────A─────┘       └────────────┘        └────────────┘       └─────┬──────┘
+#               │                                                              │
+#               └──────────────────────────────────────────────────────────────┘
+# https://doi.org/10.1109/PERCOM.2018.8444593
+
+uint8 UNKNOWN=0
+uint8 LOCATING=1
+uint8 TRACKING=2
+uint8 UNRELIABLE=3
+
+# multifloor localize status
+uint8 status


### PR DESCRIPTION
@muratams 

As we discussed, I added `MFLocalizeStatus` to enable nodes can check the multi-floor localization is ready to navigate.
Now, it announces "I am ready" when the localization is in the `MFLocalizeStatus.TRACKING` state.

Currently, `MFLocalizeStatus.UNRELIABLE` is not used because there isn't such a clear state in the `multi_floor_manager.py`.
Failure detection has one threshold, `self.rmse_threshold = 5.0` to determine if restart localization is required (only auto relocalization is enabled).
How can we implement the state?
https://github.com/CMU-cabot/cabot/blob/87cfaa6805c7920c209b2fd6da6012a68d9c5e02/mf_localization/src/multi_floor_manager.py#L358-L363

