### PR TITLE
Fix TTS node

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ CaBot v2 uses ROS1, ROS2, and ros1_bridge to use [navigation2](https://github.co
   CABOT_RECORD_ROSBAG2       # record BT log, controller critics evalation into rosbag2 (default=1)
   CABOT_DETECT_VERSION       # 1-3 (default=3)
                              # 1: python-opencv, 2: cpp-opencv-node, 3: cpp-opencv-nodelet"
+  CABOT_USE_ROBOT_TTS        # use TTS service '/speak_robot' to let PC speaker speak (default=0)
+                             # this function is not used now, but maybe used in some scenario
+  TEXT_TO_SPEECH_APIKEY      # IBM Cloud Text to Speech Service's API key and URL
+  TEXT_TO_SPEECH_URL         # these two variables are required if CABOT_USE_ROBOT_TTS is 1
   ```
 - Options for simulation
   ```

--- a/cabot_ui/launch/cabot_ble.launch
+++ b/cabot_ui/launch/cabot_ble.launch
@@ -1,0 +1,31 @@
+<!--
+ Copyright (c) 2022  Carnegie Mellon University
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+
+<launch>
+  <arg name="ble_team" default="" />
+  <arg name="ble_adapter" default="hci0"/>
+  <node ns="cabot" pkg="cabot_ui" type="cabot_ble.py"
+	name="cabot_ble_node" output="log">
+    <param name="team" value="$(arg ble_team)"/>
+    <param name="adapter" value="$(arg ble_adapter)"/>
+  </node>
+</launch>

--- a/cabot_ui/launch/cabot_menu.launch
+++ b/cabot_ui/launch/cabot_menu.launch
@@ -30,10 +30,6 @@
   <arg name="site" default=""/>
   <arg name="global_map_name" default="map" />
   <arg name="plan_topic" default="/plan" />
-  <arg name="use_tts" default="true" />
-  <arg name="use_ble" default="false" />
-  <arg name="ble_team" default="" />
-  <arg name="ble_adapter" default="hci0"/>
   <arg name="show_topology" default="false"/>
 
   <include file="$(find mongodb_store)/launch/mongodb_store.launch">
@@ -42,16 +38,6 @@
 
   <group ns="cabot">
     <rosparam file="$(eval find(site)+'/config/config.yaml')" command="load"/>
-
-    <node pkg="cabot_ui" type="tts_node.py" if="$(arg use_tts)"
-	  name="cabot_tts_node" output="$(arg output)">
-    </node>
-    <node pkg="cabot_ui" type="cabot_ble.py" if="$(arg use_ble)"
-	  name="cabot_ble_node" output="$(arg output)">
-      <param name="team" value="$(arg ble_team)"/>
-      <param name="adapter" value="$(arg ble_adapter)"/>
-	</node>
-
     
     <node pkg="cabot_ui" type="cabot_ui_manager.py"
 	  name="cabot_ui_manager"

--- a/cabot_ui/launch/cabot_tts.launch
+++ b/cabot_ui/launch/cabot_tts.launch
@@ -1,0 +1,32 @@
+<!--
+ Copyright (c) 2022  Carnegie Mellon University
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+
+<launch>
+  <arg name="iam_apikey" default="" />
+  <arg name="service_url" default=""/>
+  <node ns="cabot" pkg="cabot_ui" type="tts_node.py"
+	name="cabot_tts_node" output="log">
+    <param name="iam_apikey" value="$(arg iam_apikey)"/>
+    <param name="service_url" value="$(arg service_url)"/>
+    <remap from="/speak" to="/speak_robot"/>
+  </node>
+</launch>

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -55,6 +55,10 @@ services:
       - CABOT_INITY
       - CABOT_INITZ
       - CABOT_INITA
+# IBM Watson TTS
+      - CABOT_USE_ROBOT_TTS
+      - TEXT_TO_SPEECH_APIKEY
+      - TEXT_TO_SPEECH_URL
     volumes:
 # display
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docker/ros1/Dockerfile
+++ b/docker/ros1/Dockerfile
@@ -112,7 +112,7 @@ RUN pip3 install --upgrade pip && \
 	pip install --no-cache-dir \
         future \
 	fastdtw \
-	ibm_watson==3.4.2 \
+	ibm_watson==5.3.1 \
 	pymongo==3.12.2 \
 	pyproj \
 	pyserial \

--- a/script/cabot_ros1.sh
+++ b/script/cabot_ros1.sh
@@ -88,7 +88,12 @@ commandpost='&'
 : ${CABOT_INITA:=0}  # in degree
 
 : ${CABOT_GAZEBO:=0}
-: ${CABOT_TOUCH_ENABLED:1}
+: ${CABOT_TOUCH_ENABLED:=1}
+
+## if 1, use IBM Watson tts service for '/speak_robot' service (PC speaker)
+: ${CABOT_USE_ROBOT_TTS:=0
+: ${TEXT_TO_SPEECH_APIKEY:=}
+: ${TEXT_TO_SPEECH_URL:=}
 
 
 # command line options
@@ -114,8 +119,10 @@ no_vibration=false
 
 # fixed parameters
 use_tf_static=1
-use_tts=0
+
+## if 1, use CaBot iPhone app for '/speak' service (iPhone speaker)
 use_ble=1
+
 
 ### usage print function
 function usage {
@@ -295,7 +302,7 @@ echo "Teleop                  : $teleop"
 echo "Show Topology           : $show_topology"
 echo "No vibration            : $no_vibration"
 echo "Use TF Static           : $use_tf_static"
-echo "Use TTS                 : $use_tts"
+echo "Use TTS                 : $CABOT_USE_ROBOT_TTS"
 echo "Use BLE                 : $use_ble"
 
 rosnode list
@@ -378,9 +385,6 @@ if [ $cabot_ui_manager -eq 1 ]; then
              init_speed:='$CABOT_INIT_SPEED' \
 	     language:='$CABOT_LANG' \
 	     global_map_name:='$global_map_name' \
-	     use_tts:=$use_tts \
-             use_ble:=$use_ble \
-	     ble_team:='$CABOT_NAME' \
              site:='$CABOT_SITE' \
 	     show_topology:='$show_topology' \
 	     $commandpost"
@@ -388,6 +392,28 @@ if [ $cabot_ui_manager -eq 1 ]; then
     eval $com
     pids+=($!)
 fi
+
+if [ $CABOT_USE_ROBOT_TTS -eq 1 ]; then
+    echo "launch cabot TTS"
+    com="$command roslaunch cabot_ui cabot_tts.launch \
+             iam_apikey:='$TEXT_TO_SPEECH_APIKEY' \
+             service_url:='$TEXT_TO_SPEECH_URL' \
+	     $commandpost"
+    echo $com
+    eval $com
+    pids+=($!)
+fi
+
+if [ $use_ble -eq 1 ]; then
+    echo "launch cabot BLE"
+    com="$command roslaunch cabot_ui cabot_ble.launch \
+             ble_team:='$CABOT_NAME' \
+	     $commandpost"
+    echo $com
+    eval $com
+    pids+=($!)
+fi
+
 
 com="$command roslaunch cabot_debug record_sar.launch $commandpost"
 echo $com


### PR DESCRIPTION
TTS node, which uses IBM Watson TTS API, has not been working due to a change of authentication.

- use the latest IBM Watson python library / changed ros1 Dockerfile
- remove unused TTS methods
- add environment variables for switching TTS node launch (default false) and API keys and URL
- TTS node listen `/speak_robot` instead `/speak`
  - speak function will be provided by the iOS app (BLE node)
  - In some scenarios, the robot may need to speak (if the text is new for the robot, the robot needs to connect to the internet)
- move TTS and BLE related nodes into separate launch files
