### PR TITLE
fix error of launching navcog map server

### DIFF
--- a/cabot_ui/src/cabot_ui/datautil.py
+++ b/cabot_ui/src/cabot_ui/datautil.py
@@ -105,14 +105,17 @@ class DataUtil(object):
     def get_landmarks(self, filename=None):
         """get landmarks"""
         if filename is None:
-            req = requests.post(self.get_search_url(), data={
-                'action': 'start',
-                'user': self._user,
-                'lang': self._lang,
-                'lat': self._latitude,
-                'lng': self._longitude,
-                'dist': self._dist,
-            })
+            try:
+                req = requests.post(self.get_search_url(), data={
+                    'action': 'start',
+                    'user': self._user,
+                    'lang': self._lang,
+                    'lat': self._latitude,
+                    'lng': self._longitude,
+                    'dist': self._dist,
+                })
+            except Exception as e:
+                raise RuntimeError('could not send request to get landmarks') from None
             if req.status_code != requests.codes.ok:
                 raise RuntimeError('could not initialize landmarks') from None
             data = json.loads(req.text)
@@ -135,17 +138,20 @@ class DataUtil(object):
             raise RuntimeError("server is not initialized")
 
         if filename is None:
-            req = requests.post(self.get_search_url(), data={
-                'action': 'nodemap',
-                'user': self._user,
-                'lang': self._lang
-            })
+            try:
+                req = requests.post(self.get_search_url(), data={
+                    'action': 'nodemap',
+                    'user': self._user,
+                    'lang': self._lang
+                })
+            except Exception as e:
+                raise RuntimeError('could not send request to get node map') from None
             if req.status_code != requests.codes.ok:
                 raise RuntimeError('could not initialize node map') from None
             data = json.loads(req.text)
         else:
             data = json.load(open(filename))
-            
+
         import tempfile
         f = open(tempfile.gettempdir()+"/nodemap.json", "w")
         f.write(json.dumps(data, indent=4))
@@ -159,11 +165,14 @@ class DataUtil(object):
             raise RuntimeError("server is not initialized")
 
         if filename is None:
-            req = requests.post(self.get_search_url(), data={
-                'action': 'features',
-                'user': self._user,
-                'lang': self._lang
-            })
+            try:
+                req = requests.post(self.get_search_url(), data={
+                    'action': 'features',
+                    'user': self._user,
+                    'lang': self._lang
+                })
+            except Exception as e:
+                raise RuntimeError('could not send request to get features') from None
             if req.status_code != requests.codes.ok:
                 raise RuntimeError('could not initialize features') from None
             data = json.loads(req.text)


### PR DESCRIPTION
I had following error when launching CMU simulator model. 

```
[rospy.client][INFO] 2022-03-01 17:50:12,473: init_node, name[/cabot/navcog_map], pid[542]
[xmlrpc][INFO] 2022-03-01 17:50:12,478: XML-RPC server binding to 127.0.0.1:0
[xmlrpc][INFO] 2022-03-01 17:50:12,478: Started XML-RPC server [http://127.0.0.1:45235/]
[rospy.impl.masterslave][INFO] 2022-03-01 17:50:12,478: _ready: http://127.0.0.1:45235/
[rospy.init][INFO] 2022-03-01 17:50:12,479: ROS Slave URI: [http://127.0.0.1:45235/]
[rospy.registration][INFO] 2022-03-01 17:50:12,484: Registering with master node http://127.0.0.1:11311
[xmlrpc][INFO] 2022-03-01 17:50:12,484: xml rpc node: starting XML-RPC server
[rospy.init][INFO] 2022-03-01 17:50:12,579: registered with master
[rospy.rosout][INFO] 2022-03-01 17:50:12,579: initializing /rosout core topic
[rospy.rosout][INFO] 2022-03-01 17:50:12,581: connected to core topic /rosout
[rospy.simtime][INFO] 2022-03-01 17:50:12,582: initializing /clock core topic
[rospy.simtime][INFO] 2022-03-01 17:50:12,585: connected to core topic /clock
[rosout][INFO] 2022-03-01 17:50:12,612: Anchor file is /home/developer/catkin_ws/src/cabot_sites/cabot_sites_cmu/cabot_site_cmu_3d/maps/gazebo/cmu_gazebo_4F.yaml
[rospy.internal][INFO] 2022-03-01 17:50:12,626: topic[/tf] adding connection to [http://127.0.0.1:46877/], count 0
[rospy.internal][INFO] 2022-03-01 17:50:12,667: topic[/tf] adding connection to [http://127.0.0.1:35963/], count 1
[rosout][INFO] 2022-03-01 17:50:12,669: [40.4432590, -79.9458740](15.10)
[rosout][INFO] 2022-03-01 17:50:12,677: analyze_features 0, 0
[rosout][INFO] 2022-03-01 17:50:12,679: init server
[rospy.internal][INFO] 2022-03-01 17:50:12,682: topic[/tf] adding connection to [http://127.0.0.1:46207/], count 2
[rospy.core][INFO] 2022-03-01 17:50:12,693: signal_shutdown [atexit]
[rospy.internal][INFO] 2022-03-01 17:50:12,696: topic[/tf] adding connection to [http://127.0.0.1:41329/], count 3
[rospy.internal][INFO] 2022-03-01 17:50:12,703: topic[/tf] removing connection to http://127.0.0.1:46877/
[rospy.internal][INFO] 2022-03-01 17:50:12,704: topic[/tf] removing connection to http://127.0.0.1:35963/
[rospy.internal][INFO] 2022-03-01 17:50:12,715: topic[/tf] removing connection to http://127.0.0.1:46207/
[rospy.internal][INFO] 2022-03-01 17:50:12,715: topic[/tf] removing connection to http://127.0.0.1:41329/
[rospy.impl.masterslave][INFO] 2022-03-01 17:50:12,715: atexit
[rospy.internal][WARNING] 2022-03-01 17:50:12,716: Unknown error initiating TCP/IP socket to 127.0.0.1:37879 (http://127.0.0.1:46207/): Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/impl/tcpros_base.py", line 568, in connect
    self.write_header()
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/impl/tcpros_base.py", line 648, in write_header
    sock.setblocking(1)
OSError: [Errno 9] Bad file descriptor

```

To fix this problem, I modified datautils.py to throw exception when map request is sent before map server is launched.
Please check if this fix is OK.