### PR TITLE
Fix launch error when space separated value is set in CABOT_JETSON_CO…

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -192,7 +192,7 @@ if [ "$config_name" = "rs3" ]; then
     fi
 fi
 if [ "$config_name" = "nuc" ]; then
-    if [ -z $CABOT_JETSON_CONFIG ]; then
+    if [[ -z $CABOT_JETSON_CONFIG ]]; then
 	err "CABOT_JETSON_CONFIG: environment variable should be specified to launch people on Jetson"
 	error=1
     fi
@@ -292,10 +292,10 @@ while [ $test -eq 1 ]; do
 done
 
 ## launch jetson
-if [ ! -z $CABOT_JETSON_CONFIG ]; then
+if [[ ! -z $CABOT_JETSON_CONFIG ]]; then
     : "${CABOT_JETSON_USER:=cabot}"
 
-    if [ ! -z "$CABOT_JETSON_CONFIG" ]; then
+    if [[ ! -z "$CABOT_JETSON_CONFIG" ]]; then
         simopt=
         if [ $simulation -eq 1 ]; then simopt="-s"; fi
 


### PR DESCRIPTION
Following README, I set the following value in .env to test multiple realsense.
```
CABOT_JETSON_CONFIG="T:192.168.1.50:nano D:192.168.1.51:rs1 D:192.168.1.52:rs2 D:192.168.1.53:rs3"
```

I had following error, and I fixed launch.sh to solve this issue.
```
./launch.sh: line 295: [: too many arguments
```

