### PR TITLE
add WiFi initial localization option

### DIFF
--- a/cabot/launch/cabot2-gt1.launch
+++ b/cabot/launch/cabot2-gt1.launch
@@ -181,11 +181,20 @@ THE SOFTWARE. -->
       <param name="baud" value="115200"/>
       <param name="touch_params" type="yaml" value="$(arg touch_params)"/>
       <param name="touch_speed_max_inactive" value="0.5"/>
-      
+
       <remap from="/cabot/imu" to="/cabot/imu/data" />
       <remap from="/cabot/wrench" to="/cabot/wrench" />
       <remap from="/cabot/touch_speed" to="/cabot/touch_speed_raw" />
     </node>
+
+    <!-- (optional) run ESP32 ROS serial node for WiFi scanning -->
+    <node pkg="rosserial_python" type="serial_node.py" name="serial_esp32_wifi_scanner" output="log">
+      <param name="baud" value="115200"/>
+      <param name="port" value="/dev/ttyESP32"/>
+      <param name="verbose" value="0" />
+      <remap from="wifi_scan_str" to="/esp32/wifi_scan_str"/>
+    </node>
+
     <!--
 	Convert wrench topic to event (speed up/down, go left/right)
 	TODO: left/right is not implemented

--- a/cabot_mf_localization/script/cabot_mf_localization.sh
+++ b/cabot_mf_localization/script/cabot_mf_localization.sh
@@ -300,6 +300,7 @@ if [ $navigation -eq 0 ]; then
                     map_config_file:=$map \
                     with_odom_topic:=true \
                     beacons_topic:=$beacons_topic \
+                    wifi_topic:=$wifi_topic \
                     points2_topic:=$points2_topic \
                     imu_topic:=$imu_topic \
                     odom_topic:=$odom_topic \

--- a/cabot_mf_localization/script/cabot_mf_localization.sh
+++ b/cabot_mf_localization/script/cabot_mf_localization.sh
@@ -76,6 +76,7 @@ commandpost='&'
 points2_topic='/velodyne_points'
 imu_topic='/cabot/imu/data'
 beacons_topic='/wireless/beacons'
+wifi_topic='/esp32/wifi'
 odom_topic='/cabot/odom'
 pressure_topic='/cabot/pressure'
 publish_current_rate=0
@@ -248,6 +249,7 @@ if [ $gazebo -eq 1 ]; then
     wireless_config=$(realpath $wireless_config)
     eval "$command roslaunch mf_localization_gazebo gazebo_helper.launch \
                     beacons_topic:=$beacons_topic \
+                    wifi_topic:=$wifi_topic \
                     world_config_file:=$wireless_config \
                     $commandpost"
 

--- a/cabot_wireless_simulator/launch/wifi_sample_simulator.launch
+++ b/cabot_wireless_simulator/launch/wifi_sample_simulator.launch
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2021  IBM Corporation
+ Copyright (c) 2022  IBM Corporation
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -22,28 +22,15 @@
 
 <launch>
   <arg name="world_config_file"/>
-  <arg name="beacons_topic" default="beacons"/>
   <arg name="wifi_topic" default="wifi"/>
+  <arg name="verbose" default="false"/>
 
-  <node name="wireless_rss_simulator_node" pkg="cabot_wireless_simulator"
-      type="wireless_rss_simulator_node.py" args=""
-      output="screen">
-    <rosparam command="load" file="$(arg world_config_file)"/>
-    <param name="world_config_file" value="$(arg world_config_file)"/>
-    <remap from="beacons" to="$(arg beacons_topic)"/>
-  </node>
-
-  <node name="wifi_sample_simulator_node" pkg="cabot_wireless_simulator"
+  <node name="wireless_sample_simulator_node" pkg="cabot_wireless_simulator"
       type="wireless_sample_simulator_node.py" args=""
       output="screen">
     <rosparam command="load" file="$(arg world_config_file)"/>
     <param name="world_config_file" value="$(arg world_config_file)"/>
+    <param name="verbose" value="$(arg verbose)"/>
     <remap from="wifi" to="$(arg wifi_topic)"/>
-  </node>
-
-  <node name="floor_transition_node" pkg="mf_localization_gazebo"
-      type="floor_transition_node.py" args=""
-      output="screen">
-    <rosparam command="load" file="$(arg world_config_file)"/>
   </node>
 </launch>

--- a/cabot_wireless_simulator/script/wireless_rss_simulator.py
+++ b/cabot_wireless_simulator/script/wireless_rss_simulator.py
@@ -82,7 +82,7 @@ class SimpleBLESimulator:
             self._rmin = parameters["rmin"]
             self._sigma = parameters["sigma"]
 
-    def simulate(self, x, y, z, floor):
+    def simulate(self, x, y, z, floor, cutoff=None):
         bs = []
         for ble in self._blebeacons:
             distance = np.sqrt((x-ble._x)**2 + (y-ble._y)**2 + (z-ble._z)**2)
@@ -98,6 +98,14 @@ class SimpleBLESimulator:
 
             b = Beacon(ble._uuid, ble._major, ble._minor, rss)
             bs.append(b)
+
+        if cutoff is not None:
+            bs_filtered = []
+            for b in bs:
+                if b._rss > cutoff:
+                    bs_filtered.append(b)
+            bs = bs_filtered
+
         return bs
 
 def read_csv_blebeacons(blebeacons_file):

--- a/cabot_wireless_simulator/script/wireless_sample_simulator.py
+++ b/cabot_wireless_simulator/script/wireless_sample_simulator.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2022  IBM Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import argparse
+import json
+
+import numpy as np
+
+from sklearn.neighbors import NearestNeighbors
+
+class SampleSimulator:
+    def __init__(self, samples):
+        self.samples = samples
+        self.area_floor_const = 10000
+
+        X = []
+        for s in samples:
+            info = s["information"]
+            x = info["x"]
+            y = info["y"]
+            z = info["z"]
+            floor_num = info["floor_num"]
+            X.append([x,y,z, float(floor_num)*self.area_floor_const])
+
+        X = np.array(X)
+        nn = NearestNeighbors(n_neighbors=1)
+        nn.fit(X)
+        self.nn = nn
+
+    def simulate(self, x, y, z, floor):
+        x_query = [[x, y, z, float(floor)*self.area_floor_const]]
+        dists, indices = self.nn.kneighbors(x_query)
+        index = indices[0,0]
+        s = self.samples[index]
+        return s["data"]["beacons"]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", required=True, help="input sample json file")
+    args = parser.parse_args()
+
+    input_file = args.input
+
+    with open(input_file) as f:
+        samples = json.load(f)
+
+    sample_simulator = SampleSimulator(samples)
+
+    simulated_data = sample_simulator.simulate(0, 0, 0, 1)
+    print(simulated_data)
+    

--- a/cabot_wireless_simulator/script/wireless_sample_simulator_node.py
+++ b/cabot_wireless_simulator/script/wireless_sample_simulator_node.py
@@ -36,6 +36,7 @@ from geometry_msgs.msg import Point, Quaternion
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from gazebo_msgs.msg import ModelStates, LinkStates
 
+from wireless_utils import extract_samples
 from wireless_rss_simulator import *
 from wireless_rss_simulator_node import *
 from wireless_sample_simulator import *
@@ -79,6 +80,8 @@ def main():
     wifi_file = os.path.join( os.path.dirname(world_config_file), wifi_file)
     with open(wifi_file) as f:
         samples = json.load(f)
+
+    samples = extract_samples(samples, key="WiFi")
     wifi_simulator = SampleSimulator(samples)
 
     simulator_node = SimpleSampleSimulatorNode(model_name, robot_name, floor_list, wifi_simulator, verbose=verbose)

--- a/cabot_wireless_simulator/script/wireless_sample_simulator_node.py
+++ b/cabot_wireless_simulator/script/wireless_sample_simulator_node.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2022  IBM Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import argparse
+import ast
+import os
+
+import numpy as np
+
+import rospy
+import tf2_ros
+import tf_conversions
+from std_msgs.msg import String
+from geometry_msgs.msg import Point, Quaternion
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from gazebo_msgs.msg import ModelStates, LinkStates
+
+from wireless_rss_simulator import *
+from wireless_rss_simulator_node import *
+from wireless_sample_simulator import *
+
+class SimpleSampleSimulatorNode(SimpleBLESimulatorNode):
+
+    def simulate_message(self, timestamp, x, y, z, floor):
+        beacons = self._simulator.simulate(x, y, z, floor)
+
+        json_obj = {
+            "type": "rssi",
+            "phoneID": "gazebo_sample_simulator",
+            "timestamp": timestamp,
+            "data": beacons
+        }
+
+        string_msg = String()
+        string_msg.data = json.dumps(json_obj)
+        return string_msg
+
+def main():
+    rospy.init_node('wireless_sample_simulator')
+
+    floor_list = rospy.get_param("~floor_list")
+
+    model_name = rospy.get_param("~model/name")
+    robot_name = rospy.get_param("~robot/name")
+
+    world_config_file = rospy.get_param("~world_config_file")
+
+    # check parameter existence
+    wifi_ = rospy.get_param("~wifi", None)
+    if wifi_ is None:
+        node_name = rospy.get_name()
+        rospy.logerr("Failed to run "+node_name+": key 'wifi' is not defined in world_config_file.")
+        return
+
+    wifi_file = rospy.get_param("~wifi/samples_file")
+    verbose = rospy.get_param("~verbose", False)
+
+    wifi_file = os.path.join( os.path.dirname(world_config_file), wifi_file)
+    with open(wifi_file) as f:
+        samples = json.load(f)
+    wifi_simulator = SampleSimulator(samples)
+
+    simulator_node = SimpleSampleSimulatorNode(model_name, robot_name, floor_list, wifi_simulator, verbose=verbose)
+
+    simulator_node._beacons_pub = rospy.Publisher("wifi", String, queue_size=10)
+
+    model_sub = rospy.Subscriber("gazebo/model_states", ModelStates, simulator_node.model_callback)
+
+    rospy.spin()
+
+if __name__ == "__main__":
+    main()

--- a/cabot_wireless_simulator/script/wireless_utils.py
+++ b/cabot_wireless_simulator/script/wireless_utils.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021  IBM Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import argparse
+import copy
+
+import rospy
+import tf2_ros
+import tf_conversions
+from std_msgs.msg import String
+
+def extract_samples(samples, key="iBeacon"):
+    # key = ["iBeacon" or "WiFi"]
+    samples_new = []
+    for s in samples:
+        s2 = copy.copy(s)
+        s2_beacons = []
+        for b in s["data"]["beacons"]:
+            if b["type"] == key:
+                s2_beacons.append(b)
+        if 0 < len(s2_beacons):
+            s2["data"]["beacons"] = s2_beacons
+            samples_new.append(s2)
+        else:
+            continue
+    return samples_new

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -313,6 +313,22 @@ services:
       # - "-p"                                # people topic is simulation groundtruth
       - "-D"                                # detection
 
+  wifi_scan:
+    build:
+      context: ./wireless_scanner_ros
+    volumes:
+      - /dev:/dev
+      - /sys/devices:/sys/devices
+    privileged: true
+    devices:
+      - /dev/dri
+    cap_add:
+      - SYS_ADMIN
+      - NET_ADMIN
+    network_mode: host
+    tty: true
+    stdin_open: true
+    command: roslaunch --wait wireless_scanner_ros esp32_receiver.launch # launch only ESP32 receiver because ESP32 scanner will be launched by another service.
 
   ble_scan:
     build:

--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -60,6 +60,11 @@ services:
       - CABOT_GAZEBO=0
       - CABOT_USE_REALSENSE=1
 
+  wifi_scan:
+    extends:
+      file: docker-compose-common.yaml
+      service: wifi_scan
+
   ble_scan:
     extends:
       file: docker-compose-common.yaml

--- a/mf_localization/launch/multi_floor_2d_rss_localization.launch
+++ b/mf_localization/launch/multi_floor_2d_rss_localization.launch
@@ -26,6 +26,7 @@
 
   <arg name="map_config_file"/>
   <arg name="beacons_topic" default="beacons"/>
+  <arg name="wifi_topic" default="wifi"/>
   <arg name="with_odom_topic" default="false"/>
 
   <arg name="points2_topic" default="velodyne_points" />
@@ -51,6 +52,7 @@
     <param name="pressure_available" value="$(arg pressure_available)"/>
     <param name="verbose" value="true" />
     <remap from="beacons" to="$(arg beacons_topic)"/>
+    <remap from="wifi" to="$(arg wifi_topic)"/>
     <remap from="points2" to="$(arg points2_topic)"/>
     <remap from="imu" to="$(arg imu_topic)"/>
     <remap from="odom" to="$(arg odom_topic)"/>

--- a/mf_localization/src/multi_floor_manager.py
+++ b/mf_localization/src/multi_floor_manager.py
@@ -73,6 +73,10 @@ class LocalizationMode(Enum):
     def __str__(self):
         return self.value
 
+class RSSType(Enum):
+    iBeacon = 0
+    WiFi = 1
+
 def convert_samples_coordinate(samples, from_anchor, to_anchor, floor):
     samples2 = []
     for s in samples:
@@ -92,6 +96,7 @@ class FloorManager:
         self.node_id = None
         self.frame_id = None
         self.localizer = None
+        self.wifi_localizer = None
         self.map_filename = ""
 
         # publisher
@@ -116,6 +121,7 @@ class MultiFloorManager:
         self.valid_imu = False # state for input validation
         self.valid_points2 = False # state for input validation
         self.valid_beacon = False # state for input validation
+        self.valid_wifi = False # state for input validation
         # for optimization detection
         self.map2odom = None # state
         self.optimization_detected = False # state
@@ -126,8 +132,13 @@ class MultiFloorManager:
 
         self.ble_localizer_dict = {}
         self.ble_floor_localizer = None
+        self.wifi_floor_localizer = None
         self.pressure_available = True
         self.altitude_manager = None
+
+        # ble wifi localization
+        self.use_ble = True
+        self.use_wifi = False
 
         # area identification
         self.area_floor_const = 10000
@@ -202,6 +213,10 @@ class MultiFloorManager:
                 stat.add("Beacon input", "valid")
             else:
                 stat.add("Beacon input", "invalid")
+            if self.valid_wifi:
+                stat.add("WiFi input", "valid")
+            else:
+                stat.add("WiFi input", "invalid")
             if self.floor:
                 stat.add("Floor", self.floor)
             else:
@@ -412,14 +427,36 @@ class MultiFloorManager:
         if self.verbose:
             rospy.loginfo("multi_floor_manager.beacons_callback")
 
+        data = json.loads(message.data)
+        beacons = data["data"]
+
+        if self.use_ble:
+            self.rss_callback(beacons, rss_type=RSSType.iBeacon)
+
+    def wifi_callback(self, message):
+        self.valid_wifi = True
+        if self.verbose:
+            rospy.loginfo("multi_floor_manager.wifi_callback")
+
+        data = json.loads(message.data)
+        beacons = data["data"]
+
+        if self.use_wifi:
+            self.rss_callback(beacons, rss_type = RSSType.WiFi)
+
+    def rss_callback(self, beacons, rss_type=RSSType.iBeacon):
         if not self.is_active:
             # do nothing
             return
 
-        data = json.loads(message.data)
-        beacons = data["data"]
         # detect floor
-        loc = self.ble_floor_localizer.predict(beacons) # [[x,y,z,floor]]
+        floor_localizer = None
+        if rss_type == RSSType.iBeacon:
+            floor_localizer = self.ble_floor_localizer
+        elif rss_type == RSSType.WiFi:
+            floor_localizer = self.wifi_floor_localizer
+
+        loc = floor_localizer.predict(beacons) # [[x,y,z,floor]]
 
         if loc is None:
             return
@@ -438,7 +475,7 @@ class MultiFloorManager:
         # use one of the known floor values closest to the mean value of floor_queue
         mean_floor = np.mean(self.floor_queue)
         self.current_floor_raw_pub.publish(mean_floor)
-        
+
         idx_floor = np.abs(np.array(self.floor_list) - mean_floor).argmin()
         floor = self.floor_list[idx_floor]
 
@@ -461,14 +498,17 @@ class MultiFloorManager:
             rospy.loginfo("initialize floor = "+str(self.floor))
 
             # coarse initial localization on local frame (frame_id)
-            ble_localizer = self.ble_localizer_dict[self.floor][self.area][LocalizationMode.INIT].localizer
-            if ble_localizer is None:
-                raise RuntimeError("Unknown floor for BLE localizer "+str(self.floor))
+            localizer = None
+            if rss_type == RSSType.iBeacon:
+                localizer = self.ble_localizer_dict[self.floor][self.area][LocalizationMode.INIT].localizer
+            elif rss_type == RSSType.WiFi:
+                localizer = self.ble_localizer_dict[self.floor][self.area][LocalizationMode.INIT].wifi_localizer
 
             # local_loc is on the local coordinate on frame_id
-            local_loc = ble_localizer.predict(beacons)
+            local_loc = localizer.predict(beacons)
+
             # project loc to sample locations
-            local_loc = ble_localizer.find_closest(local_loc)
+            local_loc = localizer.find_closest(local_loc)
 
             # create a local pose instance
             position = Point(local_loc[0,0], local_loc[0,1], local_loc[0,2]) # use the estimated position
@@ -479,7 +519,7 @@ class MultiFloorManager:
 
         # floor change or init->track
         elif ((self.altitude_manager.is_height_changed() or not self.pressure_available) and self.floor != floor) \
-             or (self.mode==LocalizationMode.INIT and self.optimization_detected):            
+             or (self.mode==LocalizationMode.INIT and self.optimization_detected):
             if self.floor != floor:
                 rospy.loginfo("floor change detected (" + str(self.floor) + " -> " + str(floor) + ")." )
             else:
@@ -1099,6 +1139,10 @@ if __name__ == "__main__":
     samples_global_all = []
     floor_set = set()
 
+    # load use_ble and use_wifi
+    multi_floor_manager.use_ble = rospy.get_param("~use_ble", True)
+    multi_floor_manager.use_wifi = rospy.get_param("~use_wifi", False)
+
     # load cartographer parameters
     cartographer_parameter_converter = CartographerParameterConverter(all_params)
 
@@ -1127,12 +1171,19 @@ if __name__ == "__main__":
         for s in samples:
             s["information"]["area"] = area
 
+        # BLE beacon localizer
         # extract iBeacon samples
         samples_extracted = extract_samples(samples, key="iBeacon")
-
         # fit localizer for the floor
         ble_localizer_floor = SimpleRSSLocalizer(n_neighbors=n_neighbors_local, min_beacons=min_beacons_local, rssi_offset=rssi_offset)
         ble_localizer_floor.fit(samples_extracted)
+
+        # WiFi localizer
+        # extract wifi samples
+        samples_wifi = extract_samples(samples, key="WiFi")
+        # fit wifi localizer for the floor
+        wifi_localizer_floor = SimpleRSSLocalizer(n_neighbors=n_neighbors_local, min_beacons=min_beacons_local)
+        wifi_localizer_floor.fit(samples_wifi)
 
         if not floor in multi_floor_manager.ble_localizer_dict:
             multi_floor_manager.ble_localizer_dict[floor] = {}
@@ -1203,6 +1254,7 @@ if __name__ == "__main__":
             floor_manager = multi_floor_manager.ble_localizer_dict[floor][area][mode]
 
             floor_manager.localizer = ble_localizer_floor
+            floor_manager.wifi_localizer = wifi_localizer_floor
             floor_manager.node_id = node_id
             floor_manager.frame_id = frame_id
             floor_manager.map_filename = map_filename
@@ -1248,9 +1300,14 @@ if __name__ == "__main__":
     multi_floor_manager.floor_list = list(floor_set)
 
     # a localizer to estimate floor
+    # ble floor localizer
     samples_global_all_extracted = extract_samples(samples_global_all, key="iBeacon")
     multi_floor_manager.ble_floor_localizer = SimpleRSSLocalizer(n_neighbors=n_neighbors_floor, min_beacons=min_beacons_floor, rssi_offset=rssi_offset)
     multi_floor_manager.ble_floor_localizer.fit(samples_global_all_extracted)
+    # wifi floor localizer
+    samples_global_all_wifi = extract_samples(samples_global_all, key="WiFi")
+    multi_floor_manager.wifi_floor_localizer = SimpleRSSLocalizer(n_neighbors=n_neighbors_floor, min_beacons=min_beacons_floor)
+    multi_floor_manager.wifi_floor_localizer.fit(samples_global_all_wifi)
 
     multi_floor_manager.altitude_manager = AltitudeManager()
 
@@ -1277,6 +1334,7 @@ if __name__ == "__main__":
     scan_sub = rospy.Subscriber("scan", LaserScan, multi_floor_manager.scan_callback)
     points2_sub = rospy.Subscriber("points2", PointCloud2, multi_floor_manager.points_callback)
     beacons_sub = rospy.Subscriber("beacons", String, multi_floor_manager.beacons_callback, queue_size=1)
+    wifi_sub = rospy.Subscriber("wifi", String, multi_floor_manager.wifi_callback, queue_size=1)
     initialpose_sub = rospy.Subscriber("initialpose", PoseWithCovarianceStamped, multi_floor_manager.initialpose_callback)
     odom_sub = rospy.Subscriber("odom", Odometry, multi_floor_manager.odom_callback)
     pressure_sub = rospy.Subscriber("pressure", FluidPressure, multi_floor_manager.pressure_callback)

--- a/mf_localization/src/wireless_rss_localizer.py
+++ b/mf_localization/src/wireless_rss_localizer.py
@@ -126,6 +126,9 @@ class SimpleRSSLocalizer:
         return x
 
     def find_closest(self, x):
+        if x is None:
+            return None
+
         knnr = KNeighborsRegressor(n_neighbors=self._n_neighbors)
         X = self._X
 

--- a/mf_localization_mapping/launch/convert_rosbag_for_cartographer.launch
+++ b/mf_localization_mapping/launch/convert_rosbag_for_cartographer.launch
@@ -29,6 +29,7 @@
   <arg name="rate" default="1.0"/>
   <arg name="convert_points" default="false"/>
   <arg name="convert_imu" default="false"/>
+  <arg name="convert_esp32" default="false"/>
   <arg name="compress" default="false"/>
   <arg name="start" default="0" />
 
@@ -45,13 +46,21 @@
     <remap from="imu_out" to="imu/data"/>
   </node>
 
+  <!-- convert esp32 wifi_scan_str -->
+  <node pkg="wireless_scanner_ros" type="esp32_wifi_scan_converter.py" name="esp32_wifi_scan_converter" if="$(arg convert_esp32)">
+    <!--remap from="esp32/wifi_scan_str" to="esp32/wifi_scan_str"/-->
+    <remap from="wireless/wifi" to="esp32/wifi"/>
+  </node>
+
   <!-- play -->
   <node pkg="rosbag" type="play" name="play" args="-r $(arg rate) -s $(arg start) --clock $(arg bag_filename)" output="screen" required="true">
+    <remap from="velodyne_points" to="velodyne_points_temp" if="$(arg convert_points)"/>
+    <remap from="$(arg scan)" to="$(arg scan)_temp" if="$(arg convert_points)"/>
     <remap from="imu/data" to="imu/data_temp" if="$(arg convert_imu)"/>
   </node>
 
   <!-- record -->
   <arg name="compress_arg" value="-j" if="$(arg compress)"/>
   <arg name="compress_arg" value="" unless="$(arg compress)"/>
-  <node pkg="rosbag" type="record" name="record_required" args="/imu/data /velodyne_scan /velodyne_points /beacons /wireless/beacons /wireless/wifi $(arg compress_arg) -b 0 -O $(arg save_filename)" output="screen"/>
+  <node pkg="rosbag" type="record" name="record_required" args="/imu/data /velodyne_scan /velodyne_points /beacons /wireless/beacons /wireless/wifi /esp32/wifi $(arg compress_arg) -b 0 -O $(arg save_filename)" output="screen"/>
 </launch>

--- a/mf_localization_mapping/launch/demo_2d_VLP16.launch
+++ b/mf_localization_mapping/launch/demo_2d_VLP16.launch
@@ -25,8 +25,9 @@
   <arg name="save_state" default="false"/>
   <arg name="convert_points" default="false"/>
   <arg name="convert_imu" default="false"/>
+  <arg name="convert_esp32" default="false"/>
   <arg name="robot" default="rover"/>
-  <arg name="wireless_topics" default="['/wireless/beacons','/wireless/wifi','/beacons']"/>
+  <arg name="wireless_topics" default="['/wireless/beacons','/wireless/wifi','/beacons','/esp32/wifi']"/>
   <arg name="rate" default="1.0"/>
   <arg name="start" default="0"/>
   <arg name="load_state_filename" default=""/>
@@ -75,6 +76,12 @@
   <node pkg="mf_localization" type="imu_frame_renamer.py" name="imu_frame_renamer" output="screen" if="$(arg convert_imu)">
     <remap from="imu_in" to="$(arg imu_temp)"/>
     <remap from="imu_out" to="$(arg imu)"/>
+  </node>
+
+  <!-- convert esp32 wifi_scan_str -->
+  <node pkg="wireless_scanner_ros" type="esp32_wifi_scan_converter.py" name="esp32_wifi_scan_converter" if="$(arg convert_esp32)">
+    <!--remap from="esp32/wifi_scan_str" to="esp32/wifi_scan_str"/-->
+    <remap from="wireless/wifi" to="esp32/wifi"/>
   </node>
 
   <!-- play -->

--- a/mf_localization_mapping/launch/demo_multi_2d_VLP16_rss_localization.launch
+++ b/mf_localization_mapping/launch/demo_multi_2d_VLP16_rss_localization.launch
@@ -26,10 +26,12 @@
   <arg name="robot" default="rover"/>
 
   <arg name="convert_points" default="false"/>
+  <arg name="convert_esp32" default="false"/>
 
   <!-- multi-floor manager -->
   <arg name="map_config_file"/>
   <arg name="beacon_topic" default="beacons"/>
+  <arg name="wifi_topic" default="wifi"/>
   <arg name="rssi_offset" default=""/>
   <arg name="pressure_available" default="true"/>
   <arg name="verbose" default="false"/>
@@ -37,6 +39,8 @@
   <arg name="scan" default="velodyne_scan" />
   <arg name="points2" default="velodyne_points" />
   <arg name="imu" default="imu/data" />
+
+  <arg name="points2_temp" default="$(arg points2)_temp"/>
 
   <!-- rosbag -->
   <arg name="playbag" default="true"/>
@@ -55,6 +59,12 @@
     <arg name="scan" value="$(arg scan)"/>
   </include>
 
+  <!-- convert esp32 wifi_scan_str -->
+  <node pkg="wireless_scanner_ros" type="esp32_wifi_scan_converter.py" name="esp32_wifi_scan_converter" if="$(arg convert_esp32)">
+    <!--remap from="esp32/wifi_scan_str" to="esp32/wifi_scan_str"/-->
+    <remap from="wireless/wifi" to="esp32/wifi"/>
+  </node>
+
   <!-- map server -->
   <include file="$(find mf_localization_mapping)/launch/multi_floor_map_server.launch">
     <arg name="map_config_file" value="$(arg map_config_file)"/>
@@ -72,6 +82,7 @@
     <param name="pressure_available" value="$(arg pressure_available)"/>
     <param name="verbose" value="$(arg verbose)"/>
     <remap from="beacons" to="$(arg beacon_topic)"/>
+    <remap from="wifi" to="$(arg wifi_topic)"/>
     <remap from="points2" to="$(arg points2)"/>
     <remap from="imu" to="$(arg imu)"/>
     <remap from="scan" to="$(arg scan)"/>
@@ -85,6 +96,7 @@
   <!-- play -->
   <node name="playbag" pkg="rosbag" type="play" args="--pause --rate $(arg rate) --start $(arg start_time) --clock $(arg bag_filename)" output="screen" if="$(arg playbag)">
     <remap from="imu/data" to="imu/data"/>
+    <remap from="$(arg points2)" to="$(arg points2_temp)" if="$(arg convert_points)"/>
   </node>
 
   <!-- record -->

--- a/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch
+++ b/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch
@@ -28,7 +28,7 @@
 
   <arg name="scan" default="velodyne_scan"/>
   <arg name="save_samples" default="false"/>
-  <arg name="wireless_topics" default="['/wireless/beacons','/wireless/wifi']"/>
+  <arg name="wireless_topics" default="['/wireless/beacons','/wireless/wifi','/esp32/wifi']"/>
 
   <arg name="bag_filename" default=""/>
   <arg name="load_state_filename" default=""/>

--- a/wireless_scanner_ros/script/receiver/esp32_wifi_scan_converter.py
+++ b/wireless_scanner_ros/script/receiver/esp32_wifi_scan_converter.py
@@ -38,7 +38,7 @@ class ESP32WiFiScanConverter:
         self.last_active=None
         self.wifi_num=0
         self.accumulator = ESP32WiFiScanAccumulator()
-        self.pub = rospy.Publisher("/wireless/wifi", String, queue_size=100)
+        self.pub = rospy.Publisher("/esp32/wifi", String, queue_size=100)
         pass
 
     def convert_str(self, string):


### PR DESCRIPTION
Added a function to use WiFi scan for initial localization and floor switching.

- run ESP32 WiFi scanner if available on cabot2-gt1
- change the name of WiFi scan topic that ESP32 scanner publishes from /wireless/wifi to /esp32/wifi
- add use_wifi option for cabot_site config to enable/disable WiFi initial localization