### PR TITLE
start resetrs not individually but all at once

### DIFF
--- a/cabot_people/script/cabot_people.sh
+++ b/cabot_people/script/cabot_people.sh
@@ -42,7 +42,7 @@ function ctrl_c() {
     done
     echo \\n
     exit
-}
+} 
 
 function snore()
 {
@@ -99,6 +99,7 @@ wait_roscore=0
 roll=0
 tracking=0
 detection=0
+noreset=0
 
 ### usage print function
 function usage {
@@ -130,10 +131,11 @@ function usage {
     echo "-F <fps>                 specify camera fps"
     echo "-S <camera serial>       specify serial number of realsense camera"
     echo "-R 1280/848/640          specify camera resolution"
+    echo "-a                       no resetrs each"
     exit
 }
 
-while getopts "hdm:n:w:srqVT:Ct:pWv:N:f:KDF:S:R:" arg; do
+while getopts "hdm:n:w:srqVT:Ct:pWv:N:f:KDF:S:R:a" arg; do
     case $arg in
     h)
         usage
@@ -204,6 +206,10 @@ while getopts "hdm:n:w:srqVT:Ct:pWv:N:f:KDF:S:R:" arg; do
 	;;
     R)
 	resolution=$OPTARG
+	;;
+    a)
+	noreset=1
+	;;
     esac
 done
 shift $((OPTIND-1))
@@ -319,8 +325,10 @@ fi
 ### launch realsense camera
 if [ $realsense_camera -eq 1 ]; then
 
-    # reset RealSense port
-    sudo /resetrs.sh $serial_no
+    if [ $noreset -eq 0 ]; then
+    	# reset RealSense port
+    	sudo /resetrs.sh $serial_no
+    fi
 
     launch_file="rs_aligned_depth_1280x720_30fps.launch"
     echo "launch $launch_file"

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -312,6 +312,7 @@ services:
       - "-W"                                # wait roscore
       # - "-p"                                # people topic is simulation groundtruth
       - "-D"                                # detection
+      - "-a"                                # no resetrs individually
 
   wifi_scan:
     build:

--- a/launch.sh
+++ b/launch.sh
@@ -108,6 +108,7 @@ log_prefix=cabot
 verbose=0
 config_name=
 local_map_server=0
+reset_all_realsence=0
 
 pwd=`pwd`
 scriptdir=`dirname $0`
@@ -203,6 +204,7 @@ if [ "$config_name" = "rs3" ]; then
 	err "CABOT_REALSENSE_SERIAL_3: environment variable should be specified"
 	error=1
     fi
+    reset_all_realsence=1
 fi
 
 if [[ "$config_name" = "nuc" ]]; then
@@ -272,6 +274,12 @@ if [ $local_map_server -eq 1 ]; then
     pids+=($!)
 fi
 
+if [ $reset_all_realsence -eq 1 ]; then
+    # sudo resetsh.sh
+    sudo $scriptdir/docker/people/resetrs.sh $CABOT_REALSENSE_SERIAL_1
+    sudo $scriptdir/docker/people/resetrs.sh $CABOT_REALSENSE_SERIAL_2
+    sudo $scriptdir/docker/people/resetrs.sh $CABOT_REALSENSE_SERIAL_3
+fi
 
 if [ $verbose -eq 0 ]; then
     com2="bash -c \"$dccom --ansi never up --no-build\" > $host_ros_log_dir/docker-compose.log &"


### PR DESCRIPTION
Signed-off-by: FukiMiyazaki <f2miyazaki@lab.miraikan.jst.go.jp>

remove impurities

Signed-off-by: FukiMiyazaki <f2miyazaki@lab.miraikan.jst.go.jp>

sudo resetrs only rs3

Signed-off-by: FukiMiyazaki <f2miyazaki@lab.miraikan.jst.go.jp>

fix variable name

Signed-off-by: FukiMiyazaki <f2miyazaki@lab.miraikan.jst.go.jp>

-c rs3のオプションがついている時resetrsをそれぞれ個別ではなく、一度にまとめて呼ぶようにする