### PR TITLE
change to variable max_speed

### DIFF
--- a/cabot/launch/cabot2-gtm.launch
+++ b/cabot/launch/cabot2-gtm.launch
@@ -68,11 +68,6 @@ THE SOFTWARE. -->
   -->
   <arg name="touch_params" default="[90,30,15]"/>
   <arg name="calibration_params" default="[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"/>
-  <!--
-      @max_speed
-      change max speed parameters
-  -->
-  <arg name="max_speed" default="1.0"/>
 
 
   
@@ -261,7 +256,7 @@ THE SOFTWARE. -->
       <param name="base_frame" value="base_footprint"/>
       <param name="offset_frame" value="base_control_shift"/>
       <param name="publish_tf" value="true"/>
-      <param name="max_speed" type="yaml" value="$(arg max_speed)"/>
+      <param name="max_speed" value="$(optenv CABOT_MAX_SPEED 1.0)" />
       
       <param name="cmd_vel_input" value="/cabot/cmd_vel_limited"/>
       <param name="cmd_vel_output" value="/cabot/cmd_vel"/>

--- a/cabot/launch/cabot2-gtm.launch
+++ b/cabot/launch/cabot2-gtm.launch
@@ -68,6 +68,11 @@ THE SOFTWARE. -->
   -->
   <arg name="touch_params" default="[90,30,15]"/>
   <arg name="calibration_params" default="[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"/>
+  <!--
+      @max_speed
+      change max speed parameters
+  -->
+  <arg name="max_speed" default="1.0"/>
 
 
   
@@ -256,7 +261,7 @@ THE SOFTWARE. -->
       <param name="base_frame" value="base_footprint"/>
       <param name="offset_frame" value="base_control_shift"/>
       <param name="publish_tf" value="true"/>
-      <param name="max_speed" value="1.0" />
+      <param name="max_speed" type="yaml" value="$(arg max_speed)"/>
       
       <param name="cmd_vel_input" value="/cabot/cmd_vel_limited"/>
       <param name="cmd_vel_output" value="/cabot/cmd_vel"/>

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -47,6 +47,7 @@ services:
       - CABOT_LANG
       - CABOT_OFFSET
       - CABOT_TOUCH_PARAMS
+      - CABOT_MAX_SPEED
       - CABOT_INIT_SPEED
       - CABOT_GAMEPAD
       - CABOT_SHOW_GAZEBO_CLIENT

--- a/script/cabot_ros1.sh
+++ b/script/cabot_ros1.sh
@@ -76,7 +76,6 @@ commandpost='&'
 : ${CABOT_LANG:=en}
 : ${CABOT_OFFSET:=0.25}
 : ${CABOT_TOUCH_PARAMS:='[128,48,24]'}
-: ${CABOT_MAX_SPEED:=1.0}
 : ${CABOT_INIT_SPEED:=}
 
 : ${CABOT_GAMEPAD:=gamepad}
@@ -283,7 +282,6 @@ echo "CABOT_SITE              : $CABOT_SITE"
 echo "CABOT_LANG              : $CABOT_LANG"
 echo "CABOT_OFFSET            : $CABOT_OFFSET"
 echo "CABOT_TOUCH_PARAMS      : $CABOT_TOUCH_PARAMS"
-echo "CABOT_MAX_SPEED         : $CABOT_MAX_SPEED"
 echo "CABOT_INIT_SPEED        : $CABOT_INIT_SPEED"
 echo "CABOT_GAZEBO            : $CABOT_GAZEBO"
 echo "CABOT_TOUCH_ENABLED     : $CABOT_TOUCH_ENABLED"
@@ -343,7 +341,6 @@ if [ $CABOT_GAZEBO -eq 1 ]; then
               use_tf_static:=$use_tf_static \
 	      gui:=$CABOT_SHOW_GAZEBO_CLIENT \
 	      touch_params:=$CABOT_TOUCH_PARAMS \
-	      max_speed:=$CABOT_MAX_SPEED\
 	      camera_type:=$camera_type \
 	      use_arduino:=$use_arduino \
 	      use_speedlimit:=$use_speedlimit \
@@ -363,7 +360,6 @@ else
               use_tf_static:=$use_tf_static \
               enable_touch:=$CABOT_TOUCH_ENABLED \
 	      touch_params:=$CABOT_TOUCH_PARAMS \
-	      max_speed:=$CABOT_MAX_SPEED\
               $commandpost"
     pids+=($!)
 fi

--- a/script/cabot_ros1.sh
+++ b/script/cabot_ros1.sh
@@ -76,6 +76,7 @@ commandpost='&'
 : ${CABOT_LANG:=en}
 : ${CABOT_OFFSET:=0.25}
 : ${CABOT_TOUCH_PARAMS:='[128,48,24]'}
+: ${CABOT_MAX_SPEED:=1.0}
 : ${CABOT_INIT_SPEED:=}
 
 : ${CABOT_GAMEPAD:=gamepad}
@@ -282,6 +283,7 @@ echo "CABOT_SITE              : $CABOT_SITE"
 echo "CABOT_LANG              : $CABOT_LANG"
 echo "CABOT_OFFSET            : $CABOT_OFFSET"
 echo "CABOT_TOUCH_PARAMS      : $CABOT_TOUCH_PARAMS"
+echo "CABOT_MAX_SPEED         : $CABOT_MAX_SPEED"
 echo "CABOT_INIT_SPEED        : $CABOT_INIT_SPEED"
 echo "CABOT_GAZEBO            : $CABOT_GAZEBO"
 echo "CABOT_TOUCH_ENABLED     : $CABOT_TOUCH_ENABLED"
@@ -341,6 +343,7 @@ if [ $CABOT_GAZEBO -eq 1 ]; then
               use_tf_static:=$use_tf_static \
 	      gui:=$CABOT_SHOW_GAZEBO_CLIENT \
 	      touch_params:=$CABOT_TOUCH_PARAMS \
+	      max_speed:=$CABOT_MAX_SPEED\
 	      camera_type:=$camera_type \
 	      use_arduino:=$use_arduino \
 	      use_speedlimit:=$use_speedlimit \
@@ -360,6 +363,7 @@ else
               use_tf_static:=$use_tf_static \
               enable_touch:=$CABOT_TOUCH_ENABLED \
 	      touch_params:=$CABOT_TOUCH_PARAMS \
+	      max_speed:=$CABOT_MAX_SPEED\
               $commandpost"
     pids+=($!)
 fi


### PR DESCRIPTION
Signed-off-by: FukiMiyazaki <f2miyazaki@lab.miraikan.jst.go.jp>

最大スピードをオプション(環境変数)で変更できるように修正しました。

未来館で扱いたい内容だったのでdev-scから派生させていますが、devにもマージすべきであれば前と同じく対応致します。



GTMではオリジナルのスクリプト(launch_cabot.sh )を作成しており、オプションを指定することで変更できるようにしています。

```
ai-suitcase-1@cabot-gtm2:~$ cat launch_cabot.sh 
#!/bin/bash
check_rostopic=0
max_speed=0

while getopts "cm" arg; do
    case $arg in
	c)
	    check_rostopic=1
	    ;;
        m)
	    max_speed=1
    esac
done
shift $((OPTIND-1))

export CUDA_VISIBLE_DEVICES=0
export CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps
export CUDA_MPS_LOG_DIRECTORY=/tmp/nvidia-log
nvidia-cuda-mps-control -d
unset CUDA_VISIBLE_DEVICES

cd /home/ai-suitcase-1/cabot-dev-sc

if [ $check_rostopic -eq 1 ]; then
    gnome-terminal -- bash -c 'sleep 30; source /home/ai-suitcase-1/check_rostopic.sh; bash'
fi

com="./launch.sh -c rs3"

if [ $max_speed -eq 1 ]; then
    com="CABOT_MAX_SPEED=0.7 $com"
fi

eval $com
```