### PR TITLE
Fix bug of footprint publisher diagnosis message

### DIFF
--- a/cabot_util/cabot_util/footprint_publisher.py
+++ b/cabot_util/cabot_util/footprint_publisher.py
@@ -41,7 +41,7 @@ class Mode(enum.IntEnum):
 def check_status(stat):
     g_node.get_logger().info("check_status")
 
-    if not current_mode:
+    if current_mode is None:
         stat.summary(DiagnosticStatus.ERROR, "Mode is not specified")
         return stat
     if current_mode < 0 or 3 < current_mode:


### PR DESCRIPTION
I fixed minor issue of footprint publisher diagnosis.
When footprint mode is set as 0, error message shows as mode is not specified.
Please merge this change if there is no problem.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>