### PR TITLE
Fix build error of cabot_util for the latest ROS2

### DIFF
--- a/cabot_util/setup.cfg
+++ b/cabot_util/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/cabot_util
+script_dir=$base/lib/cabot_util
 [install]
-install-scripts=$base/lib/cabot_util
+install_scripts=$base/lib/cabot_util


### PR DESCRIPTION
When I pulled new docker image by (./manage-docker-image.sh -a pull -i all -o cmucal) and build workspace on new PC, I could not launch ROS2 with following error.

```
ros2_1          | Task exception was never retrieved
ros2_1          | future: <Task finished name='Task-2' coro=<LaunchService._process_one_event() done, defined at /opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py:226> exception=SubstitutionFailure("package 'cabot_util' found at '/home/developer/ros2_ws/install/cabot_util', but libexec directory '/home/developer/ros2_ws/install/cabot_util/lib/cabot_util' does not exist")>
ros2_1          | Traceback (most recent call last):
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py", line 228, in _process_one_event
ros2_1          |     await self.__process_event(next_event)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py", line 248, in __process_event
ros2_1          |     visit_all_entities_and_collect_futures(entity, self.__context))
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
ros2_1          |     futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
ros2_1          |     futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
ros2_1          |     futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
ros2_1          |   [Previous line repeated 1 more time]
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 38, in visit_all_entities_and_collect_futures
ros2_1          |     sub_entities = entity.visit(context)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/action.py", line 108, in visit
ros2_1          |     return self.execute(context)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch_ros/actions/node.py", line 484, in execute
ros2_1          |     ret = super().execute(context)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/actions/execute_process.py", line 837, in execute
ros2_1          |     self.__expand_substitutions(context)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/actions/execute_process.py", line 681, in __expand_substitutions
ros2_1          |     cmd = [perform_substitutions(context, x) for x in self.__cmd]
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/actions/execute_process.py", line 681, in <listcomp>
ros2_1          |     cmd = [perform_substitutions(context, x) for x in self.__cmd]
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/perform_substitutions_impl.py", line 26, in perform_substitutions
ros2_1          |     return ''.join([context.perform_substitution(sub) for sub in subs])
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/perform_substitutions_impl.py", line 26, in <listcomp>
ros2_1          |     return ''.join([context.perform_substitution(sub) for sub in subs])
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch/launch_context.py", line 197, in perform_substitution
ros2_1          |     return substitution.perform(self)
ros2_1          |   File "/opt/ros/galactic/lib/python3.8/site-packages/launch_ros/substitutions/executable_in_package.py", line 79, in perform
ros2_1          |     raise SubstitutionFailure(
ros2_1          | launch.substitutions.substitution_failure.SubstitutionFailure: package 'cabot_util' found at '/home/developer/ros2_ws/install/cabot_util', but libexec directory '/home/developer/ros2_ws/install/cabot_util/lib/cabot_util' does not exist
```

To fix this issue, I modified setup.cfg of cabot_util.
For the latest ROS2, "script_dir", "install_scripts" should be used instead of "script-dir", "install-scripts".

[Old document for galactic](https://docs.ros.org/en/galactic/How-To-Guides/Developing-a-ROS-2-Package.html#python-packages)
[New document for humble](https://docs.ros.org/en/humble/How-To-Guides/Developing-a-ROS-2-Package.html#python-packages)

Please merge this change if there is no problem.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>