### PR TITLE
fix button bug that it is judged to push twice even though only push …

### DIFF
--- a/cabot/python/cabot/handle_v2.py
+++ b/cabot/python/cabot/handle_v2.py
@@ -78,7 +78,8 @@ class Handle:
 
         self.eventSub = rospy.Subscriber('/cabot/event', String, self.event_callback)
 
-    interval = 0.25
+    double_click_interval = 0.25
+    ignore_interval = 0.05
     lastUp = [None, None, None, None]
     upCount = [0, 0, 0, 0]
     btnDwn = [False, False, False, False]
@@ -99,7 +100,7 @@ class Handle:
         now = rospy.get_rostime().to_sec()
         if msg.data and not self.btnDwn[index]:
             if self.lastUp[index] is not None and \
-               now - self.lastUp[index] < self.interval-0.2:
+               now - self.lastUp[index] < self.ignore_interval:
                    self.upCount[index] -= 1
                    self.lastUp[index] = None
             else:
@@ -112,7 +113,7 @@ class Handle:
             self.btnDwn[index] = False
         if self.lastUp[index] is not None and \
            not self.btnDwn[index] and \
-           now - self.lastUp[index] > self.interval:
+           now - self.lastUp[index] > self.double_click_interval:
             event = {"buttons":key, "count":self.upCount[index]}
             self.lastUp[index] = None
             self.upCount[index] = 0

--- a/cabot/python/cabot/handle_v2.py
+++ b/cabot/python/cabot/handle_v2.py
@@ -98,7 +98,12 @@ class Handle:
         event = None
         now = rospy.get_rostime().to_sec()
         if msg.data and not self.btnDwn[index]:
-            event = {"button":key, "up":False}
+            if self.lastUp[index] is not None and \
+               now - self.lastUp[index] < self.interval-0.2:
+                   self.upCount[index] -= 1
+                   self.lastUp[index] = None
+            else:
+                event = {"button":key, "up":False}
             self.btnDwn[index] = True
         if not msg.data and self.btnDwn[index]:
             event = {"button":key, "up":True}
@@ -106,6 +111,7 @@ class Handle:
             self.lastUp[index] = now
             self.btnDwn[index] = False
         if self.lastUp[index] is not None and \
+           not self.btnDwn[index] and \
            now - self.lastUp[index] > self.interval:
             event = {"buttons":key, "count":self.upCount[index]}
             self.lastUp[index] = None

--- a/cabot/python/cabot/handle_v2.py
+++ b/cabot/python/cabot/handle_v2.py
@@ -98,13 +98,10 @@ class Handle:
     def _button_check(self, msg, key, index):
         event = None
         now = rospy.get_rostime().to_sec()
-        if msg.data and not self.btnDwn[index]:
-            if self.lastUp[index] is not None and \
-               now - self.lastUp[index] < self.ignore_interval:
-                   self.upCount[index] -= 1
-                   self.lastUp[index] = None
-            else:
-                event = {"button":key, "up":False}
+        if msg.data and not self.btnDwn[index] and \
+           not (self.lastUp[index] is not None and \
+           now - self.lastUp[index] < self.ignore_interval):
+            event = {"button":key, "up":False}
             self.btnDwn[index] = True
         if not msg.data and self.btnDwn[index]:
             event = {"button":key, "up":True}


### PR DESCRIPTION
…once

Signed-off-by: FukiMiyazaki <f2miyazaki@lab.miraikan.jst.go.jp>

何らかのバグにより一回クリックした(downとupの)間に短時間のupとdownが入ることがあるため、2度押した判定になる。
それを回避するために、up後にごく僅かな時間の間にdownが起こった場合はそのdownを無視するように修正を入れました。
その時の直前のupは対処できないので「self.btnDwn[index] = True」は残しておき、正常なupの際にup判定がされるようにしました。
ただ、設定した短い時間はかなり早く押せば人でも起こせる長さではあります。しかし、それより短くしてしまうとバグでのupdownを判定できなくなるのと、ある程度の速さのダブルクリックではその長さを超えるのでこれぐらい(現状0.05)が適切と判断しました。

また、最後のupからself.interval後にupが起きなければリセットするようになっていましたが、ダブルクリックの2回目が少し長く押してしまった際に一回ずつ押された判定(ダブルクリックにならない)になるのでup状態であることを追加条件にしました。