### PR TITLE
use ROS timer instead of std::thread and use multi thread spinner

### DIFF
--- a/track_people_cpp/src/detect_darknet_opencv.cpp
+++ b/track_people_cpp/src/detect_darknet_opencv.cpp
@@ -98,42 +98,9 @@ namespace TrackPeopleCPP
       
     detected_boxes_pub_ = nh.advertise<track_people_py::TrackedBoxes>("/track_people_py/detected_boxes", 1);
 
-    loop_thread_ = std::thread([](DetectDarknetOpencv *obj){
-	ros::TimerEvent event;
-        std::chrono::time_point<std::chrono::high_resolution_clock> last = std::chrono::high_resolution_clock::now();
-	while(ros::ok()) {
-	  auto now = std::chrono::high_resolution_clock::now();
-	  auto diff = ((double)(now - last).count())/1000000000;
-	  if (obj->is_ready_ && diff > 1.0 / obj->target_fps_) {
-            last = std::chrono::high_resolution_clock::now();
-	    obj->fps_loop_cb(event);
-	  }
-	  std::this_thread::sleep_for(std::chrono::milliseconds(1));
-	}
-      }, this);
-    //fps_loop_ = nh.createTimer(ros::Duration(1.0 / target_fps_), &DetectDarknetOpencv::fps_loop_cb, this);
-    //detect_loop_ = nh.createTimer(ros::Duration(0.01), &DetectDarknetOpencv::detect_loop_cb, this);
-    //depth_loop_ = nh.createTimer(ros::Duration(0.01), &DetectDarknetOpencv::depth_loop_cb, this);
-
-    detect_thread_ = std::thread([](DetectDarknetOpencv *obj){
-	ros::TimerEvent event;
-	while(ros::ok()) {
-	  if (obj->is_ready_) {
-	    obj->detect_loop_cb(event);
-	  }
-	  std::this_thread::sleep_for(std::chrono::milliseconds(1));
-	}
-      }, this);
-    
-    depth_thread_ = std::thread([](DetectDarknetOpencv *obj){
-	ros::TimerEvent event;
-	while(ros::ok()) {
-	  if (obj->is_ready_) {
-	    obj->depth_loop_cb(event);
-	  }
-	  std::this_thread::sleep_for(std::chrono::milliseconds(1));
-	}
-      }, this);
+    fps_loop_ = nh.createTimer(ros::Duration(1.0 / target_fps_), &DetectDarknetOpencv::fps_loop_cb, this);
+    detect_loop_ = nh.createTimer(ros::Duration(0.01), &DetectDarknetOpencv::detect_loop_cb, this);
+    depth_loop_ = nh.createTimer(ros::Duration(0.01), &DetectDarknetOpencv::depth_loop_cb, this);
 
     updater_.setHardwareID(nh.getNamespace());
     diagnostic_updater::FrequencyStatusParam param1(&target_fps_, &target_fps_, 1.0, 2);

--- a/track_people_cpp/src/detect_darknet_opencv.hpp
+++ b/track_people_cpp/src/detect_darknet_opencv.hpp
@@ -23,7 +23,6 @@
 #ifndef DETECT_DARKNET_OPENCV_HPP
 #define DETECT_DARKNET_OPENCV_HPP
 
-#include <thread>
 #include <mutex>
 
 #include <ros/ros.h>
@@ -149,10 +148,6 @@ namespace TrackPeopleCPP
     ros::Timer fps_loop_;
     ros::Timer detect_loop_;
     ros::Timer depth_loop_;
-
-    std::thread loop_thread_;
-    std::thread detect_thread_;
-    std::thread depth_thread_;
 
     message_filters::Subscriber<sensor_msgs::Image>* rgb_image_sub_;
     message_filters::Subscriber<sensor_msgs::Image>* depth_image_sub_;

--- a/track_people_cpp/src/detect_darknet_opencv_node.cpp
+++ b/track_people_cpp/src/detect_darknet_opencv_node.cpp
@@ -30,6 +30,7 @@ int main(int argc, char **argv)
   TrackPeopleCPP::DetectDarknetOpencv impl;
   impl.onInit(nh);
 
-  ros::spin();
+  ros::MultiThreadedSpinner spinner(4);
+  spinner.spin();
   return 0;
 }

--- a/track_people_cpp/src/detect_darknet_opencv_nodelet.cpp
+++ b/track_people_cpp/src/detect_darknet_opencv_nodelet.cpp
@@ -46,7 +46,7 @@ namespace TrackPeopleCPP
 
     void onInit()
     {
-      ros::NodeHandle &nh = getNodeHandle();
+      ros::NodeHandle &nh = getMTNodeHandle();
       impl->onInit(nh);
     }
   }; // class DetectDarknetOpencvNodelet


### PR DESCRIPTION
@tatsuya-ishihara 
Could you review the change?
I didn't know the multi-thread spinning APIs and tried to use my own thread to keep the FPS up.
However, it looks like a cause of a bug in a certain situation. 

So, now I reuse ROS timer and use multi-thread spinning both in node and nodelet implementation.
I could not reproduce the bug situation, so I just tested if it was working in a test condition (a few people) without navigation.