### PR TITLE
Fix launch error when CABOT_DETECT_VERSION is set as python-opencv

### DIFF
--- a/docker/people/requirements.txt
+++ b/docker/people/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.19.2
 open3d==0.13.0
 scikit-learn==0.24.0
 scipy==1.5.4
+pandas==1.4.4


### PR DESCRIPTION
I fixed launch error when CABOT_DETECT_VERSION is set as 1 (python-opencv).
pandas is recently updated to 1.5.0 automatically and it requires numpy later than 1.20.3, so I fixed pandas version as 1.4.4.
Please review change and merge if it is OK.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>