### PR TITLE
announce only when needed

### DIFF
--- a/cabot_ui/src/cabot_ui/navgoal.py
+++ b/cabot_ui/src/cabot_ui/navgoal.py
@@ -742,8 +742,11 @@ class NarrowGoal(NavGoal):
         self._is_canceled = (status != GoalStatus.SUCCEEDED)
         if self._is_canceled:
             return
-        self.delegate.please_return_position()
-        self.wait_next_navi(status)
+        if self._need_to_announce_follow:
+            self.delegate.please_return_position()
+            self.wait_next_navi(status)
+        else:
+            self._is_completed = (status == GoalStatus.SUCCEEDED)
 
     def narrow_enter(self):
         super(NavGoal, self).enter()


### PR DESCRIPTION
Signed-off-by: FukiMiyazaki <f2miyazaki@lab.miraikan.jst.go.jp>
狭い道を入る時に必要があればアナウンスするようにしていたが、狭い道を抜ける時に必ず元の位置に戻るアナウンスをするままになっていたので抜ける時も必要がある時のみにしました。