### PR TITLE
Fix people workspace build error

### DIFF
--- a/docker/people/Dockerfile
+++ b/docker/people/Dockerfile
@@ -169,6 +169,7 @@ RUN apt update && \
 	apt-get install -y --no-install-recommends \
 	libogg-dev \
         libtheora-dev \
+	libturbojpeg0-dev \
 	ros-$ROS_DISTRO-diagnostic-updater \
 	&& \
 	apt-get clean && \


### PR DESCRIPTION
I found a following error when building people workspace.
This error is caused because the latest people docker image does not include libturbojpeg0-dev.
Please merge if this change is OK.

```
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
-- queue_msgs: 1 messages, 0 services
-- +++ processing catkin package: 'ddynamic_reconfigure'
-- ==> add_subdirectory(ddynamic_reconfigure)
CMake Deprecation Warning at ddynamic_reconfigure/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- +++ processing catkin package: 'camera_calibration_parsers'
-- ==> add_subdirectory(image_common/camera_calibration_parsers)
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.8.so (found version "3.8.10") 
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0") found components: filesystem python 
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Checking for module 'yaml-cpp'
--   Found yaml-cpp, version 0.6.2
-- +++ processing catkin package: 'cv_bridge'
-- ==> add_subdirectory(vision_opencv/cv_bridge)
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0") found components: python 
-- Found CUDA: /usr/local/cuda (found suitable exact version "11.1") 
-- Found OpenCV: /usr/local (found suitable version "4.5.4", minimum required is "4") found components: opencv_core opencv_imgproc opencv_imgcodecs 
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.8.so (found suitable version "3.8.10", minimum required is "3.8") 
-- +++ processing catkin package: 'image_geometry'
-- ==> add_subdirectory(vision_opencv/image_geometry)
-- Found OpenCV: /usr/local (found version "4.5.4") 
-- +++ processing catkin package: 'image_transport'
-- ==> add_subdirectory(image_common/image_transport)
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0") found components: filesystem 
-- +++ processing catkin package: 'camera_info_manager'
-- ==> add_subdirectory(image_common/camera_info_manager)
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0")  
-- +++ processing catkin package: 'compressed_depth_image_transport'
-- ==> add_subdirectory(image_transport_plugins/compressed_depth_image_transport)
-- Checking to see if CXX compiler accepts flag -Wl,--version-script,"/home/developer/people_ws/build/image_transport_plugins/compressed_depth_image_transport/class_loader_hide_library_symbols__compressed_depth_image_transport.script"
-- Checking to see if CXX compiler accepts flag -Wl,--version-script,"/home/developer/people_ws/build/image_transport_plugins/compressed_depth_image_transport/class_loader_hide_library_symbols__compressed_depth_image_transport.script" - yes
-- +++ processing catkin package: 'compressed_image_transport'
-- ==> add_subdirectory(image_transport_plugins/compressed_image_transport)
-- Checking for module 'libturbojpeg'
--   No package 'libturbojpeg' found
CMake Error at /usr/share/cmake-3.19/Modules/FindPkgConfig.cmake:553 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.19/Modules/FindPkgConfig.cmake:741 (_pkg_check_modules_internal)
  image_transport_plugins/compressed_image_transport/CMakeLists.txt:8 (pkg_check_modules)


-- Configuring incomplete, errors occurred!
See also "/home/developer/people_ws/build/CMakeFiles/CMakeOutput.log".
See also "/home/developer/people_ws/build/CMakeFiles/CMakeError.log".
Invoking "cmake" failed
```
DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>