### PR TITLE
fix bags of track people function

### DIFF
--- a/docker/people/Dockerfile.nuc
+++ b/docker/people/Dockerfile.nuc
@@ -61,10 +61,11 @@ RUN apt update && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir \
-	matplotlib \
-	scipy \
-	filterpy \
-	pyyaml
+	matplotlib==3.6.3 \
+	scipy==1.10.0 \
+	filterpy==1.4.5 \
+	pyyaml==5.3.1 \
+	numpy==1.24.1
 
 # install cmake
 RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_V}/cmake-${CMAKE_V}-linux-x86_64.sh && \

--- a/track_people_py/scripts/track_sort_3d_people.py
+++ b/track_people_py/scripts/track_sort_3d_people.py
@@ -85,8 +85,8 @@ class TrackSort3dPeople(AbsTrackPeople):
         start_time = time.time()
         try:
             _, id_list, color_list, tracked_duration = self.tracker.track(detected_boxes_msg.header.stamp, detect_results, center_bird_eye_global_list, self.frame_id)
-        except:
-            rospy.logerr("tracking error")
+        except Exception as e:
+            rospy.logerr("tracking error, " + str(e))
             self.processing_detected_boxes = False
             return
         elapsed_time = time.time() - start_time

--- a/track_people_py/scripts/track_sort_3d_people.py
+++ b/track_people_py/scripts/track_sort_3d_people.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import copy
 import os
 import sys
 
@@ -71,12 +72,12 @@ class TrackSort3dPeople(AbsTrackPeople):
         combined_msg = None
 
         for key in self.buffer:
-            msg = self.buffer[key]
+            msg = copy.deepcopy(self.buffer[key])
             if not combined_msg:
                 combined_msg = msg
             else:
                 combined_msg.tracked_boxes.extend(msg.tracked_boxes)
-        self.buffer = {detected_boxes_msg.camera_id: detected_boxes_msg}
+        self.buffer[detected_boxes_msg.camera_id] = detected_boxes_msg
 
         detect_results, center_bird_eye_global_list = self.preprocess_msg(combined_msg)
 

--- a/track_people_py/scripts/track_utils/tracker_sort_3d.py
+++ b/track_people_py/scripts/track_utils/tracker_sort_3d.py
@@ -90,10 +90,10 @@ class TrackerSort3D:
             center_circle_list.append([center_pos[0], center_pos[1], self.iou_circle_size])
         
         # prepare output
-        prev_exist = np.zeros(len(bboxes)).astype(np.bool)
-        person_id = (-np.ones(len(bboxes))).astype(np.int)
+        prev_exist = np.zeros(len(bboxes)).astype(np.bool8)
+        person_id = (-np.ones(len(bboxes))).astype(np.int8)
         person_color = [None]*len(bboxes)
-        tracked_duration = np.zeros(len(bboxes)).astype(np.float)
+        tracked_duration = np.zeros(len(bboxes)).astype(np.float32)
         
         if (len(bboxes) == 0) and (len(self.box_active) == 0):
             # No new detection and no active tracks


### PR DESCRIPTION
I fixed following bugs in this pull request
- numpy is updated to updated to 1.24.1 for the latest people-nuc image, and track code uses deprecated data type (np.int, np.bool) since 1.24
- specify versions of python libraries in people-nuc image to prevent automatic updates
- in multiple camera setting, tracking code may output multiple people for one person 