### PR TITLE
Fix bug of previous pull request to fix people tracking, change data type of people ID

### DIFF
--- a/track_people_py/scripts/track_utils/tracker_sort_3d.py
+++ b/track_people_py/scripts/track_utils/tracker_sort_3d.py
@@ -91,7 +91,7 @@ class TrackerSort3D:
         
         # prepare output
         prev_exist = np.zeros(len(bboxes)).astype(np.bool8)
-        person_id = (-np.ones(len(bboxes))).astype(np.int8)
+        person_id = np.zeros(len(bboxes)).astype(np.uint32)
         person_color = [None]*len(bboxes)
         tracked_duration = np.zeros(len(bboxes)).astype(np.float32)
         


### PR DESCRIPTION
I fixed a bug of previous pull request #83.
Data type of person ID is 8bit integer. 
After person ID 127, person ID -128 will be created and cause following error.
I changed data type of person ID as unsigned 32bit integer to fix this.

```
[rosout][INFO] 2023-01-30 16:28:12,449: detected_boxes_cb
[rospy.topics][ERROR] 2023-01-30 16:28:12,456: Traceback (most recent call last):
  File "/home/developer/people_nuc_ws/devel/lib/python3/dist-packages/track_people_py/msg/_TrackedBoxes.py", line 222, in serialize
    buff.write(_get_struct_I().pack(_x))
struct.error: argument out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 882, in publish
    self.impl.publish(data)
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 1066, in publish
    serialize_message(b, self.seq, message)
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/msg.py", line 152, in serialize_message
    msg.serialize(b)
  File "/home/developer/people_nuc_ws/devel/lib/python3/dist-packages/track_people_py/msg/_TrackedBoxes.py", line 238, in serialize
    except struct.error as se: self._check_types(struct.error("%s: '%s' when writing '%s'" % (type(se), str(se), str(locals().get('_x', self)))))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 393, in _check_types
    check_type(n, t, getattr(self, n))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 314, in check_type
    check_type(field_name + '[]', base_type, v)
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 324, in check_type
    check_type('%s.%s' % (field_name, n), t, getattr(field_val, n))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 267, in check_type
    raise SerializationError('field %s must be unsigned integer type' % field_name)
genpy.message.SerializationError: field tracked_boxes[].track_id must be unsigned integer type

[rosout][INFO] 2023-01-30 16:28:12,453: detected_boxes_cb
[rosout][ERROR] 2023-01-30 16:28:12,458: bad callback: <bound method TrackSort3dPeople.detected_boxes_cb of <__main__.TrackSort3dPeople object at 0x7ff785fbbdf0>>
Traceback (most recent call last):
  File "/home/developer/people_nuc_ws/devel/lib/python3/dist-packages/track_people_py/msg/_TrackedBoxes.py", line 222, in serialize
    buff.write(_get_struct_I().pack(_x))
struct.error: argument out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 882, in publish
    self.impl.publish(data)
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 1066, in publish
    serialize_message(b, self.seq, message)
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/msg.py", line 152, in serialize_message
    msg.serialize(b)
  File "/home/developer/people_nuc_ws/devel/lib/python3/dist-packages/track_people_py/msg/_TrackedBoxes.py", line 238, in serialize
    except struct.error as se: self._check_types(struct.error("%s: '%s' when writing '%s'" % (type(se), str(se), str(locals().get('_x', self)))))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 393, in _check_types
    check_type(n, t, getattr(self, n))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 314, in check_type
    check_type(field_name + '[]', base_type, v)
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 324, in check_type
    check_type('%s.%s' % (field_name, n), t, getattr(field_val, n))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 267, in check_type
    raise SerializationError('field %s must be unsigned integer type' % field_name)
genpy.message.SerializationError: field tracked_boxes[].track_id must be unsigned integer type

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/developer/people_nuc_ws/src/track_people_py/scripts/track_sort_3d_people.py", line 96, in detected_boxes_cb
    self.pub_result(combined_msg, id_list, color_list, tracked_duration)
  File "/home/developer/people_nuc_ws/src/track_people_py/scripts/track_abstract_people.py", line 107, in pub_result
    self.tracked_boxes_pub.publish(tracked_boxes_msg)
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 886, in publish
    raise ROSSerializationException(str(e))
rospy.exceptions.ROSSerializationException: field tracked_boxes[].track_id must be unsigned integer type
``` 

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>