### PR TITLE
fix bug of predict people code when any cameras stop in multiple camera settings

### DIFF
--- a/predict_people_py/scripts/predict_kf_abstract.py
+++ b/predict_people_py/scripts/predict_kf_abstract.py
@@ -186,16 +186,16 @@ class PredictKfAbstract():
                 
                 # update buffer for FPS
                 if track_id in self.track_prev_predict_timestamp:
-                    if tbox.header.stamp.to_sec() < self.track_prev_predict_timestamp[track_id][-1]:
+                    if tbox.header.stamp.to_sec() <= self.track_prev_predict_timestamp[track_id][-1]:
                         # rospy.logwarn("skip wrong time order box. box timestamp = " + str(tbox.header.stamp.to_sec())
                         #               + "track_id = " + str(track_id) + ", previous time stamp for track = " + str(self.track_prev_predict_timestamp[track_id][-1]))
                         continue
                     # calculate average FPS in past frames
-                    self.track_predict_fps[track_id] = len(self.track_prev_predict_timestamp[track_id])/(msg.header.stamp.to_sec()-self.track_prev_predict_timestamp[track_id][0])
+                    self.track_predict_fps[track_id] = len(self.track_prev_predict_timestamp[track_id])/(tbox.header.stamp.to_sec()-self.track_prev_predict_timestamp[track_id][0])
                     # rospy.loginfo("track_id = " + str(track_id) + ", FPS = " + str(self.track_predict_fps[track_id]))
                 if track_id not in self.track_prev_predict_timestamp:
                     self.track_prev_predict_timestamp[track_id] = deque(maxlen=self.fps_est_time)
-                self.track_prev_predict_timestamp[track_id].append(msg.header.stamp.to_sec())
+                self.track_prev_predict_timestamp[track_id].append(tbox.header.stamp.to_sec())
         
         # predict
         track_pos_dict = {}
@@ -245,7 +245,7 @@ class PredictKfAbstract():
         # clean up missed track if necessary
         missing_track_id_list = set(self.predict_buf.track_input_queue_dict.keys()) - set(alive_track_id_list)
         stop_publish_track_id_list = set()
-        now = msg.header.stamp
+        now = rospy.Time.now()
         for track_id in missing_track_id_list:
             # update missing time
             if track_id not in self.predict_buf.track_id_missing_time_dict:

--- a/predict_people_py/scripts/predict_kf_abstract.py
+++ b/predict_people_py/scripts/predict_kf_abstract.py
@@ -39,14 +39,12 @@ from collections import deque
 from scipy.linalg import block_diag
 from filterpy.kalman import KalmanFilter
 from filterpy.common import Q_discrete_white_noise
-from matplotlib import pyplot as plt
 from diagnostic_updater import Updater, DiagnosticTask, HeaderlessTopicDiagnostic, FrequencyStatusParam
 from diagnostic_msgs.msg import DiagnosticStatus
 
 
 class PredictKfBuffer():
-    def __init__(self, input_time, output_time, duration_inactive_to_remove):
-        self.duration_inactive_to_remove = duration_inactive_to_remove
+    def __init__(self):
         self.track_input_queue_dict = {}
         self.track_color_dict = {}
         
@@ -55,13 +53,9 @@ class PredictKfBuffer():
 
 
 class PredictKfAbstract():
-    def __init__(self, input_time, output_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time):
-        # settings for visualization
-        self.vis_pred_image = False
-        
+    def __init__(self, input_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time):
         # start initialization
         self.input_time = input_time
-        self.output_time = output_time
         self.duration_inactive_to_remove = duration_inactive_to_remove
         self.duration_inactive_to_stop_publish = duration_inactive_to_stop_publish
         self.fps_est_time = fps_est_time
@@ -72,17 +66,12 @@ class PredictKfAbstract():
         self.track_vel_hist_dict = {}
         
         # buffers to predict
-        self.predict_buf = PredictKfBuffer(self.input_time, self.output_time, self.duration_inactive_to_remove)
+        self.predict_buf = PredictKfBuffer()
         
         # set subscriber, publisher
         self.tracked_boxes_sub = rospy.Subscriber('track_people_py/tracked_boxes', TrackedBoxes, self.tracked_boxes_cb, queue_size=10)
         self.people_pub = rospy.Publisher('people', People, queue_size=10)
         self.vis_marker_array_pub = rospy.Publisher('predict_people_py/visualization_marker_array', MarkerArray, queue_size=10)
-
-        # buffer to merge people tracking, prediction results before publish
-        self.camera_id_predicted_tracks_dict = {}
-        self.camera_id_people_dict = {}
-        self.camera_id_vis_marker_array_dict = {}
     
         self.updater = Updater()
         rospy.Timer(rospy.Duration(1), lambda e: self.updater.update())
@@ -102,8 +91,6 @@ class PredictKfAbstract():
         pass
 
     def vis_result(self, msg, alive_track_id_list, track_pos_dict, track_vel_dict):
-        input_pose = msg.pose
-        
         # publish visualization marker array for rviz
         marker_array = MarkerArray()
         # plot sphere for current position, arrow for current direction
@@ -164,57 +151,7 @@ class PredictKfAbstract():
                 marker.color.a = 0.5
             marker_array.markers.append(marker)
 
-        # merge marker array from multiple camera before publish
-        #self.camera_id_vis_marker_array_dict[msg.camera_id] = copy.copy(marker_array.markers)
-        #for camera_id in self.camera_id_vis_marker_array_dict.keys():
-        #    if camera_id!=msg.camera_id and len(self.camera_id_vis_marker_array_dict[camera_id])>0:
-        #        marker_array.markers.extend(self.camera_id_vis_marker_array_dict[camera_id])
         self.vis_marker_array_pub.publish(marker_array)
-        
-        if self.vis_pred_image:
-            # prepare plot
-            plt.figure(1)
-            plt.cla()
-            ax = plt.gca()
-            ax.set_title("predict people in global")
-            ax.grid(True)
-            ax.legend()
-            ax.set_xlabel('y')
-            ax.set_ylabel('x')
-            
-            # plot prediction
-            plt_x = []
-            plt_y = []
-            plt_color = []
-            for track_id in track_pred_dict.keys():
-                track_predict = track_pred_dict[track_id]
-                for row_idx, row in enumerate(track_predict):
-                    plt_x.append(-track_predict[row_idx][1])
-                    plt_y.append(track_predict[row_idx][0])
-                    plt_color.append(np.array(self.predict_buf.track_color_dict[track_id]))
-            plt.scatter(plt_x, plt_y, c=plt_color, marker='o')
-            
-            # plot prediction origin
-            plt_x = []
-            plt_y = []
-            plt_color = []
-            for track_id in track_pred_dict.keys():
-                if len(self.predict_buf.track_input_queue_dict[track_id]) < self.input_time:
-                    continue
-                
-                past = np.array(self.predict_buf.track_input_queue_dict[track_id])[:,:2]
-                predict_origin = past[-1,:].copy()
-                plt_x.append(-track_predict[row_idx][1])
-                plt_y.append(track_predict[row_idx][0])
-                plt_color.append(np.array(self.predict_buf.track_color_dict[track_id]))
-            plt.scatter(plt_x, plt_y, c=plt_color, marker='s')
-            
-            plt.scatter([-input_pose.position.y], [input_pose.position.x], c=[np.array([1.0, 0.0, 0.0])], marker='+')
-            ax.set_xlim([-input_pose.position.y-20,-input_pose.position.y+20])
-            ax.set_ylim([input_pose.position.x-20,input_pose.position.x+20])
-            plt.draw()
-            plt.pause(0.00000000001)
-    
     
     def tracked_boxes_cb(self, msg):
         self.on_tracked_boxes_cb(msg)

--- a/predict_people_py/scripts/predict_kf_obstacle.py
+++ b/predict_people_py/scripts/predict_kf_obstacle.py
@@ -45,8 +45,8 @@ from diagnostic_msgs.msg import DiagnosticStatus
 from predict_kf_abstract import PredictKfAbstract 
 
 class PredictKfObstacle(PredictKfAbstract):
-    def __init__(self, input_time, output_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time):
-        PredictKfAbstract.__init__(self, input_time, output_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time)
+    def __init__(self, input_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time):
+        PredictKfAbstract.__init__(self, input_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time)
 
     def pub_result(self, msg, alive_track_id_list, track_pos_dict, track_vel_dict, track_vel_hist_dict):
         self.htd.tick()
@@ -92,24 +92,17 @@ class PredictKfObstacle(PredictKfAbstract):
 
             people_msg.people.append(person)
 
-
-        # merge people from multiple camera before publish
-        # self.camera_id_people_dict[msg.camera_id] = copy.copy(people_msg.people)
-        # for camera_id in self.camera_id_people_dict.keys():
-        #    if camera_id!=msg.camera_id and len(self.camera_id_people_dict[camera_id])>0:
-        #        people_msg.people.extend(self.camera_id_people_dict[camera_id])
         self.people_pub.publish(people_msg)
     
 def main():
     rospy.init_node('predict_obstacle_py', anonymous=True)
 
     input_time = 5 # number of frames to start prediction
-    output_time = 5 # number of frames to predict
     duration_inactive_to_remove = 2.0 # duration (seconds) for a track to be inactive before removal (this value should be enough long because track_obstacle_py resturns recovered tracks)
     duration_inactive_to_stop_publish = 0.2 # duration (seconds) for a track to be inactive before stop publishing in people topic
     fps_est_time = 100 # number of frames which are used to estimate FPS
     
-    predict_people = PredictKfObstacle(input_time, output_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time)
+    predict_people = PredictKfObstacle(input_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time)
     
     try:
         plt.ion()

--- a/predict_people_py/scripts/predict_kf_people.py
+++ b/predict_people_py/scripts/predict_kf_people.py
@@ -29,8 +29,8 @@ from matplotlib import pyplot as plt
 from predict_kf_abstract import PredictKfAbstract 
 
 class PredictKfPeople(PredictKfAbstract):
-    def __init__(self, input_time, output_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time, publish_simulator_people):
-        PredictKfAbstract.__init__(self, input_time, output_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time)
+    def __init__(self, input_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time, publish_simulator_people):
+        PredictKfAbstract.__init__(self, input_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time)
 
         # start initialization
         self.publish_simulator_people = publish_simulator_people
@@ -116,12 +116,11 @@ def main():
     publish_simulator_people = rospy.get_param("~publish_simulator_people")
 
     input_time = 5 # number of frames to start prediction
-    output_time = 5 # number of frames to predict
     duration_inactive_to_remove = 2.0 # duration (seconds) for a track to be inactive before removal (this value should be enough long because track_people_py resturns recovered tracks)
     duration_inactive_to_stop_publish = 0.2 # duration (seconds) for a track to be inactive before stop publishing in people topic
     fps_est_time = 100 # number of frames which are used to estimate FPS
     
-    predict_people = PredictKfPeople(input_time, output_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time, publish_simulator_people)
+    predict_people = PredictKfPeople(input_time, duration_inactive_to_remove, duration_inactive_to_stop_publish, fps_est_time, publish_simulator_people)
     
     try:
         plt.ion()

--- a/track_people_py/scripts/track_abstract_people.py
+++ b/track_people_py/scripts/track_abstract_people.py
@@ -46,10 +46,6 @@ class AbsTrackPeople:
     
     
     def __init__(self, device, minimum_valid_track_duration):
-        # settings for visualization
-        self.vis_local = False
-        self.vis_global = False
-
         # make sure only one camera is processed
         self.processing_detected_boxes = False
         
@@ -136,30 +132,3 @@ class AbsTrackPeople:
             marker.color.a = 1.0
             marker_array.markers.append(marker)
         self.visualization_marker_array_pub.publish(marker_array)
-        
-        # visualize by 2D plot in global map
-        if self.vis_global:
-            plt_x = []
-            plt_y = []
-            plt_color = []
-            for idx_bbox, bbox in enumerate(detected_boxes_msg.tracked_boxes):
-                if tracked_duration[idx_bbox] < self.minimum_valid_track_duration:
-                    continue
-                plt_x.append(bbox.x)
-                plt_y.append(bbox.y)
-                plt_color.append(np.array(color_list[idx_bbox]))
-            
-            plt.figure(2)
-            plt.cla()
-            ax = plt.gca()
-            ax.set_title("tracked people in global, camera="+detected_boxes_msg.camera_id)
-            ax.grid(True)
-            ax.legend()
-            ax.set_xlabel('y')
-            ax.set_ylabel('x')
-            plt.scatter(plt_x, plt_y, c=plt_color)
-            plt.scatter([-detected_boxes_msg_msg.pose.position.y], [detected_boxes_msg_msg.pose.position.x], c=[np.array([1.0, 0.0, 0.0])], marker='+')
-            ax.set_xlim([-detected_boxes_msg_msg.pose.position.y-20,-detected_boxes_msg_msg.pose.position.y+20])
-            ax.set_ylim([detected_boxes_msg_msg.pose.position.x-20,detected_boxes_msg_msg.pose.position.x+20])
-            plt.draw()
-            plt.pause(0.00000000001)

--- a/track_people_py/scripts/track_abstract_people.py
+++ b/track_people_py/scripts/track_abstract_people.py
@@ -22,6 +22,7 @@
 
 from abc import ABCMeta, abstractmethod
 from collections import deque
+import threading
 import time
 
 from geometry_msgs.msg import PoseStamped
@@ -47,8 +48,8 @@ class AbsTrackPeople:
     
     def __init__(self, device, minimum_valid_track_duration):
         # make sure only one camera is processed
-        self.processing_detected_boxes = False
-        
+        self.lock_detected_boxes = threading.Lock()
+
         # start initialization
         rospy.init_node('track_people_py', anonymous=True)
         

--- a/track_people_py/scripts/track_sort_3d_people.py
+++ b/track_people_py/scripts/track_sort_3d_people.py
@@ -54,44 +54,47 @@ class TrackSort3dPeople(AbsTrackPeople):
         if not hasattr(self, 'tracker'):
             return
 
+        # make sure if only one camera is processed
+        self.lock_detected_boxes.acquire()
+
+        now = rospy.Time.now()
+
+        # To ignore cameras which stop by accidents, remove detecion results for cameras that are not updated longer than threshold to remove track
+        delete_camera_ids = []
+        for key in self.buffer:
+            if (now - self.buffer[key].header.stamp) > self.tracker.duration_inactive_to_remove:
+                delete_camera_ids.append(key)
+        for key in delete_camera_ids:
+            rospy.loginfo("delete buffer for the camera which is not updated, camera ID = " + str(key))
+            del self.buffer[key]
+
         # 2022.01.12: remove time check for multiple detection
         # check if image is received in correct time order
         # cur_detect_time_sec = detected_boxes_msg.header.stamp.to_sec()
         # if cur_detect_time_sec<self.prev_detect_time_sec:
         #    return
 
-        if detected_boxes_msg.camera_id not in self.buffer:
-            self.buffer[detected_boxes_msg.camera_id] = detected_boxes_msg
-            return
-
-        # make sure if only one camera is processed
-        if self.processing_detected_boxes:
-            return
-        self.processing_detected_boxes = True
+        self.buffer[detected_boxes_msg.camera_id] = detected_boxes_msg
 
         combined_msg = None
-
         for key in self.buffer:
             msg = copy.deepcopy(self.buffer[key])
             if not combined_msg:
                 combined_msg = msg
             else:
                 combined_msg.tracked_boxes.extend(msg.tracked_boxes)
-        self.buffer[detected_boxes_msg.camera_id] = detected_boxes_msg
+        combined_msg.header.stamp = now
 
         detect_results, center_bird_eye_global_list = self.preprocess_msg(combined_msg)
 
         self.combined_detected_boxes_pub.publish(combined_msg)
 
-        start_time = time.time()
         try:
-            _, id_list, color_list, tracked_duration = self.tracker.track(detected_boxes_msg.header.stamp, detect_results, center_bird_eye_global_list, self.frame_id)
+            _, id_list, color_list, tracked_duration = self.tracker.track(combined_msg.header.stamp, detect_results, center_bird_eye_global_list, self.frame_id)
         except Exception as e:
             rospy.logerr("tracking error, " + str(e))
-            self.processing_detected_boxes = False
+            self.lock_detected_boxes.release()
             return
-        elapsed_time = time.time() - start_time
-        # rospy.loginfo("time for tracking :{0}".format(elapsed_time) + "[sec]")
         
         self.pub_result(combined_msg, id_list, color_list, tracked_duration)
         
@@ -99,7 +102,7 @@ class TrackSort3dPeople(AbsTrackPeople):
         
         self.frame_id += 1
         # self.prev_detect_time_sec = cur_detect_time_sec
-        self.processing_detected_boxes = False
+        self.lock_detected_boxes.release()
 
 
 def main():


### PR DESCRIPTION
I fixed following items in this pull request
- remove unused code in predict people code (https://github.com/CMU-cabot/cabot/issues/88)
- fix error of predict people code when any cameras stop in multiple camera settings