### PR TITLE
Add cabot2-gtm-outdoor config

### DIFF
--- a/cabot/launch/cabot2-gtm-outdoor-remote.launch
+++ b/cabot/launch/cabot2-gtm-outdoor-remote.launch
@@ -43,7 +43,7 @@ THE SOFTWARE. -->
     
     <param name="max_acc" value="1.2"/>
     <param name="target_rate" value="20"/>
-    <param name="bias" value="0.21"/> <!--wheel separation-->
+    <param name="bias" value="0.26"/> <!--wheel separation-->
     
     <param name="gain_omega" value="1.0"/>
     <param name="gain_omega_i" value="0.0"/>
@@ -54,18 +54,18 @@ THE SOFTWARE. -->
       Motor Controller (ODrive)
   -->
   <node pkg="odriver" type="odriver_node.py" name="odriver_node" output="log">
-    <param name="wheel_diameter" value="0.073" />
-    <param name="count_per_round" value="16384" />
-    <param name="left_is_1" value="ture" />
-    <param name="is_clockwise" value="true" />
+    <param name="wheel_diameter" value="0.200" />
+    <param name="count_per_round" value="90" />
+    <param name="left_is_1" value="false" />
+    <param name="is_clockwise" value="false" />
     <param name="gain_left" value="1.0" />
     <param name="gain_right" value="1.0" />
     <param name="port" value="/dev/ttyODRIVE" />
     
-    <param name="vel_gain" value="1.0" />
+    <param name="vel_gain" value="6.0" />
     <param name="vel_integrator_gain" value="10.0" />
-    <param name="motor_bandwidth" value="200" />
-    <param name="encoder_bandwidth" value="200" />
+    <param name="motor_bandwidth" value="100" />
+    <param name="encoder_bandwidth" value="100" />
   </node>
 
   <arg name="joy_dev" default="/dev/input/js0" />

--- a/cabot/launch/cabot2-gtm-outdoor.launch
+++ b/cabot/launch/cabot2-gtm-outdoor.launch
@@ -21,7 +21,7 @@ THE SOFTWARE. -->
 
 <launch>
   <!--
-      Launch file for CaBot2-gtm
+      Launch file for CaBot2-gtm-outdoor
       Development history:
       CaBot2-e1 is deprecated because of motor precision issue (might be because
       of no-encoder, no-PID adjustment, and cheep motors)
@@ -73,7 +73,7 @@ THE SOFTWARE. -->
   
   <!-- INTERNAL VARIABLES -->
   <!-- robot name and type-->
-  <arg name="robot" default="cabot2-gtm"/>
+  <arg name="robot" default="cabot2-gtm-outdoor"/>
   <param name="robot/name" value="$(optenv ROBOT CaBot2)"/>
   <param name="robot/type" value="$(arg robot)"/>
   <arg name="urdf_file"
@@ -130,7 +130,7 @@ THE SOFTWARE. -->
   
   
   <!--
-      CaBot2-gtm specification
+      CaBot2-gtm-outdoor specification
       1. Odrive motor controller (serial)
       2. Arduino Mega
       - IMU
@@ -359,7 +359,7 @@ THE SOFTWARE. -->
 
       <param name="max_acc" value="1.2"/>
       <param name="target_rate" value="20"/>
-      <param name="bias" value="0.21"/> <!--wheel separation-->
+      <param name="bias" value="0.26"/> <!--wheel separation-->
 
       <param name="gain_omega" value="1.0"/>
       <param name="gain_omega_i" value="0.0"/>
@@ -370,18 +370,18 @@ THE SOFTWARE. -->
 	Cabot-E Motor Controller (ODrive)
     -->
     <node pkg="odriver" type="odriver_node.py" name="odriver_node" output="log">
-      <param name="wheel_diameter" value="0.073" />
-      <param name="count_per_round" value="16384" />
-      <param name="left_is_1" value="true" />
-      <param name="is_clockwise" value="true" />
+      <param name="wheel_diameter" value="0.200" />
+      <param name="count_per_round" value="90" />
+      <param name="left_is_1" value="false" />
+      <param name="is_clockwise" value="false" />
       <param name="gain_left" value="1.0" />
       <param name="gain_right" value="1.0" />
       <param name="port" value="/dev/ttyODRIVE" />
 
-      <param name="vel_gain" value="1.0" />
+      <param name="vel_gain" value="6.0" />
       <param name="vel_integrator_gain" value="10.0" />
-      <param name="motor_bandwidth" value="200" />
-      <param name="encoder_bandwidth" value="200" />
+      <param name="motor_bandwidth" value="100" />
+      <param name="encoder_bandwidth" value="100" />
 
       <remap from="/motorTarget" to="/cabot/motorTarget" />
       <remap from="/motorStatus" to="/cabot/motorStatus" />

--- a/cabot/launch/cabot2-gtm-outdoor.launch
+++ b/cabot/launch/cabot2-gtm-outdoor.launch
@@ -98,7 +98,7 @@ THE SOFTWARE. -->
   
 
   <group if="$(arg use_velodyne)">
-    <include file="$(find cabot)/launch/includes/vlp16.launch.xml">
+    <include file="$(find cabot)/launch/includes/vlp16-front.launch.xml">
     </include>
   </group>
   <group unless="$(arg use_velodyne)">

--- a/cabot/launch/cabot2-gtm.launch
+++ b/cabot/launch/cabot2-gtm.launch
@@ -98,7 +98,7 @@ THE SOFTWARE. -->
   
 
   <group if="$(arg use_velodyne)">
-    <include file="$(find cabot)/launch/includes/vlp16.launch.xml">
+    <include file="$(find cabot)/launch/includes/vlp16-front.launch.xml">
     </include>
   </group>
   <group unless="$(arg use_velodyne)">

--- a/cabot/launch/includes/vlp16-front.launch.xml
+++ b/cabot/launch/includes/vlp16-front.launch.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0"?>
+<!-- Copyright (c) 2020  Carnegie Mellon University
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. -->
+
+<launch>
+  <arg name="calibration" default="$(find velodyne_pointcloud)/params/VLP16db.yaml"/>
+  <arg name="device_ip" default="" />
+  <arg name="frame_id" default="velodyne" />
+  <arg name="manager" default="$(arg frame_id)_nodelet_manager" />
+  <arg name="max_range" default="130.0" />
+  <arg name="min_range" default="0.4" />
+  <arg name="pcap" default="" />
+  <arg name="port" default="2368" />
+  <arg name="read_fast" default="false" />
+  <arg name="read_once" default="false" />
+  <arg name="repeat_delay" default="0.0" />
+  <arg name="rpm" default="600.0" />
+  <arg name="gps_time" default="false" />
+  <arg name="cut_angle" default="-0.01" />
+  <arg name="laserscan_ring" default="-1" />
+  <arg name="laserscan_resolution" default="0.007" />
+  <arg name="organize_cloud" default="false" />
+  
+  <!-- start nodelet manager and driver nodelets -->
+  <include file="$(find velodyne_driver)/launch/nodelet_manager.launch">
+    <arg name="device_ip" value="$(arg device_ip)"/>
+    <arg name="frame_id" value="$(arg frame_id)"/>
+    <arg name="manager" value="$(arg manager)" />
+    <arg name="model" value="VLP16"/>
+    <arg name="pcap" value="$(arg pcap)"/>
+    <arg name="port" value="$(arg port)"/>
+    <arg name="read_fast" value="$(arg read_fast)"/>
+    <arg name="read_once" value="$(arg read_once)"/>
+    <arg name="repeat_delay" value="$(arg repeat_delay)"/>
+    <arg name="rpm" value="$(arg rpm)"/>
+    <arg name="gps_time" value="$(arg gps_time)"/>
+    <arg name="cut_angle" value="$(arg cut_angle)"/>
+  </include>
+  
+  <!-- start cloud nodelet -->
+  <include file="$(find velodyne_pointcloud)/launch/cloud_nodelet.launch">
+    <arg name="calibration" value="$(arg calibration)"/>
+    <arg name="manager" value="$(arg manager)" />
+    <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="min_range" value="$(arg min_range)"/>
+    <arg name="organize_cloud" value="$(arg organize_cloud)"/>
+  </include>
+  
+  <!-- start laserscan nodelet -->
+  <node pkg="nodelet" type="nodelet" name="$(arg manager)_laserscan"
+        args="load velodyne_laserscan/LaserScanNodelet $(arg manager)">
+    <param name="ring" value="$(arg laserscan_ring)"/>
+    <param name="resolution" value="$(arg laserscan_resolution)"/>
+    <remap from="scan" to="scan1"/>
+    </node>
+
+  <!-- run pointcloud_to_laserscan node -->
+  <node pkg="nodelet" type="nodelet" name="pointcloud_to_laserscan_node"
+        args="load pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet $(arg manager)">
+
+    <remap from="cloud_in" to="/velodyne_points"/>
+    <remap from="scan" to="/scan"/>
+    <rosparam>
+      target_frame: velodyne # Leave disabled to output scan in pointcloud frame
+      transform_tolerance: 0.01
+      min_height: -0.10 # origin is the sensor
+      max_height: 1.4 # origin is the sensor
+      angle_min: -1.0  # - 1.0 (angle clipping)
+      angle_max: 3.14
+      angle_increment: 0.00436 # M_PI/360/2
+      scan_time: 0.1
+      range_min: 0.2
+      range_max: 50
+      use_inf: true
+      inf_epsilon: 1.0
+
+      # Concurrency level, affects number of pointclouds queued for
+      # processing and number of threads used
+      # 0 : Detect number of cores
+      # 1 : Single threaded
+      # 2->inf : Parallelism level
+      concurrency_level: 0
+    </rosparam>
+  </node>
+
+  <!-- run pcl crop box filter node -->
+  <node pkg="nodelet" type="nodelet" name="pcl_crop_box_node"
+        args="load pcl/CropBox $(arg manager)" output="screen">
+    <remap from="~input" to="/velodyne_points" />
+    <remap from="~output" to="/velodyne_points_cropped" />
+    <!-- crop box where user can stand -->
+    <rosparam>
+      min_x: -0.75
+      min_y: -0.85
+      min_z: 0
+      max_x: 0.2
+      max_y: 0.1
+      max_z: 2
+      keep_organized: false
+      negative: true
+      input_frame: "base_link"
+      output_frame: "velodyne"
+    </rosparam>
+  </node>
+</launch>

--- a/cabot_description/robots/cabot2-gtm-outdoor.urdf.xacro
+++ b/cabot_description/robots/cabot2-gtm-outdoor.urdf.xacro
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+
+<!--
+ Copyright (c) 2020  Carnegie Mellon University
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+<robot name="cabot" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- robot rotation center offset -->
+  <xacro:arg name="offset" default="0" />
+  <!-- flag to extend hokuyo lidar range in simulation -->
+  <xacro:arg name="extended" default="0" />
+  
+  <xacro:arg name="sim" default="true" />
+ 
+  <!-- velodyne -->
+  <xacro:arg name="use_velodyne" default="true" />
+
+  <!-- camera type -->
+  <xacro:arg name="camera_type" default="realsense" />
+  <xacro:property name="camera_type" value="$(arg camera_type)" />
+
+  
+
+  <!-- include xacro macros -->
+  <xacro:include filename="$(find cabot_description)/urdf/cabot2-gtm-outdoor_description.urdf" />
+  <xacro:include filename="$(find cabot_description)/urdf/sensors/hokuyo_ust_20lx.urdf.xacro"/>
+  <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/>
+  <xacro:include filename="$(find cabot_description)/urdf/sensors/imu_sensor.urdf.xacro"/>
+  <xacro:include filename="$(find cabot_description)/urdf/sensors/_d455.urdf.xacro"/>
+  <xacro:include filename="$(find cabot_description)/urdf/sensors/_d435.urdf.xacro"/>
+
+  
+  <!-- content -->
+  
+  <!-- cabot description -->
+  <xacro:cabot offset="$(arg offset)" sim="$(arg sim)"/>
+
+  <!-- add link to lidar and camera -->
+  <link name="lidar_link">
+  </link>
+  <joint name="lidar_base" type="fixed">
+    <!--<origin xyz="0.15 0.0 0.12" rpy="0 0 0"/>-->
+      <origin xyz="0.111 0.0 0.584" rpy="0 0 0"/> <!-- lidar base points to the left direction.-->
+      <parent link="base_link"/>
+      <child link="lidar_link"/>
+    </joint>
+    
+  <link name="rs1_link">
+  </link>
+  <joint name="rs1_base" type="fixed">
+      <origin xyz="0.179 0.0 0.548" rpy="0 0 0"/>
+      <parent link="base_link"/>
+      <child link="rs1_link"/>
+  </joint>
+  <link name="rs2_link">
+  </link>
+  <joint name="rs2_base" type="fixed">
+      <origin xyz="0.123 0.063 0.548" rpy="0 0 1.344"/>
+      <parent link="base_link"/>
+      <child link="rs2_link"/>
+  </joint>
+  <link name="rs3_link">
+  </link>
+  <joint name="rs3_base" type="fixed">
+      <origin xyz="0.123 -0.063 0.548" rpy="0 0 -1.344"/>
+      <parent link="base_link"/>
+      <child link="rs3_link"/>
+  </joint>
+
+  <!-- IMU sensor description-->
+  <xacro:imu_macro prefix="cabot/imu" frame="imu_frame"/>
+
+  <!-- Hokuyo UST 20LX -->
+  <xacro:unless value="$(arg use_velodyne)">
+    <xacro:sensor_hokuyo_ust_20lx parent="lidar_link" extended="$(arg extended)"
+			    min_angle="-2.27" max_angle="2.0"/>
+  </xacro:unless>
+  <!-- rotated min_angle="-0.9" and max_angle="3.14" from forward to left direction -->
+
+
+  <!-- Velodyne VLP-16 -->
+  <xacro:if value="$(arg use_velodyne)">
+    <xacro:arg name="gpu" default="true"/>
+    <xacro:property name="gpu" value="$(arg gpu)" />
+    <xacro:VLP-16 parent="lidar_link" name="velodyne" topic="/velodyne_points"
+	    hz="20" gpu="${gpu}" min_range="0.3">
+      <origin xyz="0 0 0.0" rpy="0 0 0" />
+    </xacro:VLP-16>
+  </xacro:if>
+  
+  <!-- RealSense D455 -->
+  <xacro:if value="${camera_type=='realsense'}">
+    <xacro:sensor_d455 parent="rs1_link" name="rs1_d455" topics_ns="rs1">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:sensor_d455>
+  </xacro:if>
+
+  <!-- RealSense D435 -->
+  <xacro:if value="${camera_type=='realsense'}">
+    <xacro:sensor_d435 parent="rs2_link" name="rs2_d435" topics_ns="rs2">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:sensor_d435>
+  </xacro:if>
+  <xacro:if value="${camera_type=='realsense'}">
+    <xacro:sensor_d435 parent="rs3_link" name="rs3_d435" topics_ns="rs3">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:sensor_d435>
+  </xacro:if>
+</robot>

--- a/cabot_description/robots/cabot2-gtm-outdoor.urdf.xacro
+++ b/cabot_description/robots/cabot2-gtm-outdoor.urdf.xacro
@@ -56,11 +56,19 @@
   <link name="lidar_link">
   </link>
   <joint name="lidar_base" type="fixed">
-    <!--<origin xyz="0.15 0.0 0.12" rpy="0 0 0"/>-->
-      <origin xyz="0.111 0.0 0.584" rpy="0 0 0"/> <!-- lidar base points to the left direction.-->
+      <origin xyz="0.111 0.0 0.584" rpy="0 0 0"/>
       <parent link="base_link"/>
       <child link="lidar_link"/>
     </joint>
+
+  <!-- add link to gps--> <!-- lidar + 0.1m in z-direction -->
+  <link name="gps">
+  </link>
+  <joint name="gps_base" type="fixed">
+      <origin xyz="0.111 0.0 0.684" rpy="0 0 0"/>
+      <parent link="base_link"/>
+      <child link="gps"/>
+  </joint>
     
   <link name="rs1_link">
   </link>
@@ -100,7 +108,7 @@
     <xacro:arg name="gpu" default="true"/>
     <xacro:property name="gpu" value="$(arg gpu)" />
     <xacro:VLP-16 parent="lidar_link" name="velodyne" topic="/velodyne_points"
-	    hz="20" gpu="${gpu}" min_range="0.3">
+	    hz="10" gpu="${gpu}" min_range="0.3">
       <origin xyz="0 0 0.0" rpy="0 0 0" />
     </xacro:VLP-16>
   </xacro:if>

--- a/cabot_description/urdf/cabot2-gtm-outdoor_description.urdf
+++ b/cabot_description/urdf/cabot2-gtm-outdoor_description.urdf
@@ -1,0 +1,395 @@
+<!-- Copyright (c) 2020  Carnegie Mellon University
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. -->
+
+<robot name="cabot_description"
+  xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="M_PI" value="3.1415926535897931" />
+
+  <xacro:macro name="cabot" params="offset:=^ sim:=^|true">
+    <xacro:property name="BODY_X" value="0.368" />
+    <xacro:property name="BODY_Y" value="0.175" />
+    <xacro:property name="BODY_Z" value="0.466" />
+    <xacro:property name="WHEEL_RADIUS" value="0.10" />
+    <xacro:property name="CLEARANCE" value="0.154027" />
+    <xacro:property name="WHEEL_WIDTH" value="0.05" />
+    <xacro:property name="WHEEL_BIAS" value="0.264" />
+    <xacro:property name="OMNI_RADIUS" value="0.10" />
+    <xacro:property name="OMNI_WIDTH" value="0.025" />
+    <xacro:property name="FREEWHEEL_BIAS" value="0.2406" />
+
+    <xacro:if value="${sim}">
+    <gazebo>
+      <plugin name="differential_drive_controller" filename="libgazebo_ros_diff_drive.so">
+        <legacyMode>false</legacyMode>
+        <alwaysOn>true</alwaysOn>
+        <publishWheelTF>false</publishWheelTF>
+        <publishTf>1</publishTf>
+        <publishOdomTF>true</publishOdomTF>
+        <publishWheelJointState>true</publishWheelJointState>
+        <updateRate>10.0</updateRate>
+        <leftJoint>awl_joint</leftJoint>
+        <rightJoint>awr_joint</rightJoint>
+        <wheelSeparation>0.210</wheelSeparation>
+        <wheelDiameter>0.073</wheelDiameter>
+        <wheelAcceleration>1.0</wheelAcceleration>
+        <wheelTorque>20</wheelTorque>
+        <commandTopic>/cabot/cmd_vel</commandTopic>
+        <odometrySource>0</odometrySource>
+        <odometryTopic>/odom</odometryTopic>
+        <odometryFrame>odom</odometryFrame>
+        <robotBaseFrame>base_footprint</robotBaseFrame>
+      </plugin>
+    </gazebo>
+
+    <xacro:macro name="gazebo_wheel" params="reference">
+      <gazebo reference="${reference}">
+        <mu1>1.0</mu1>
+        <mu2>1.0</mu2>
+        <kp>1000000.0</kp>
+        <kd>100.0</kd>
+        <minDepth>0.001</minDepth>
+        <maxVel>1.0</maxVel>
+      </gazebo>
+    </xacro:macro>
+
+    <xacro:macro name="gazebo_free_wheel" params="reference">
+      <gazebo reference="${reference}">
+        <material>Gazebo/Black</material>
+        <mu1>0.00</mu1>
+        <mu2>0.00</mu2>
+        <kp>1000000.0</kp>
+        <kd>100.0</kd>
+        <minDepth>0.001</minDepth>
+        <maxVel>1.0</maxVel>
+      </gazebo>
+    </xacro:macro>
+
+    <xacro:macro name="gazebo_color" params="reference color">
+      <gazebo reference="${reference}">
+        <material>${color}</material>
+      </gazebo>
+    </xacro:macro>
+
+    <xacro:gazebo_wheel reference="awl_link"/>
+    <xacro:gazebo_wheel reference="awr_link"/>
+    <xacro:gazebo_free_wheel reference="vc1_link"/>
+    <xacro:gazebo_free_wheel reference="vc2_link"/>
+    <xacro:gazebo_color reference="base_link" color="Gazebo/DarkGrey" />
+    <xacro:gazebo_color reference="awl_link" color="Gazebo/DarkGrey" />
+    <xacro:gazebo_color reference="awr_link" color="Gazebo/DarkGrey" />
+    <xacro:gazebo_color reference="pw2_link" color="Gazebo/DarkGrey" />
+    <xacro:gazebo_color reference="pw4_link" color="Gazebo/DarkGrey" />
+    <xacro:gazebo_color reference="handle_link" color="Gazebo/Gold" />
+    <xacro:gazebo_color reference="glip_link" color="Gazebo/DarkGrey" />
+    </xacro:if>
+
+    <xacro:macro name="gold_material">
+      <material name="gold">
+        <color rgba="0.698 0.505 0.015 1" />
+      </material>
+    </xacro:macro>
+    <xacro:macro name="alminium_material">
+      <material name="alminium">
+        <color rgba="0.9576 0.9594 0.9572 1" />
+      </material>
+    </xacro:macro>
+    <xacro:macro name="black_material">
+      <material name="black">
+        <color rgba="0.1 0.1 0.1 1" />
+      </material>
+    </xacro:macro>
+
+    <link name="base_footprint"/>
+    <link name="base_control_shift"/>
+    <!-- link name="imu_frame_xsens"/ -->
+    <link name="imu_frame"/>
+
+    <joint name="base_joint" type="fixed">
+      <origin xyz="0 ${offset} ${WHEEL_RADIUS}" rpy="0 0 0" />
+      <parent link="base_footprint"/>
+      <child link="base_control_shift" />
+    </joint>
+
+    <joint name="control_center_joint" type="fixed">
+      <origin xyz="${-BODY_X/2 + 0.0519} 0 0" rpy="0 0 0" />
+      <parent link="base_control_shift"/>
+      <child link="base_link" />
+    </joint>
+
+    <!-- xsens is not used -->
+    <!--
+    <joint name="imu_joint_xsens" type="fixed">
+      <origin xyz="-0.05 0.10 0.30" rpy="0 ${M_PI} 0" />
+      <parent link="base_link"/>
+      <child link="imu_frame_xsens" />
+    </joint>
+    -->
+
+    <joint name="imu_joint" type="fixed">
+      <origin xyz="0.01 0.00 0.38" rpy="0 0 0" />
+      <parent link="base_link"/>
+      <child link="imu_frame" />
+    </joint>
+
+    <link name="base_link">
+      <inertial>
+        <origin xyz="0 0 0.1" rpy="0 0 0" />
+        <mass value="16" />
+        <inertia ixx="0.60813333" ixy="0" ixz="0" iyy="0.40213333" iyz="0" izz="0.41026667" />
+      </inertial>
+      <!-- main body -->
+      <visual>
+        <origin xyz="0 0 ${BODY_Z/2 + CLEARANCE - WHEEL_RADIUS}" rpy="0 0 0" />
+        <geometry>
+          <box size="${BODY_X} ${BODY_Y} ${BODY_Z}" />
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <collision>
+        <origin xyz="0 0 ${BODY_Z/2 + CLEARANCE - WHEEL_RADIUS}" rpy="0 0 0" />
+        <geometry>
+          <box size="${BODY_X} ${BODY_Y} ${BODY_Z}" />
+        </geometry>
+      </collision>
+
+      <!-- base sheet metal -->
+      <visual>
+        <origin xyz="0 0 0.025" rpy="0 0 0" />
+        <geometry>
+          <box size="${BODY_X} ${BODY_Y} 0.01" />
+        </geometry>
+        <xacro:alminium_material/>
+      </visual>
+      <!-- motor control unit -->
+      <visual>
+        <origin xyz="${BODY_X/2 - 0.0519} ${BODY_Y/2 - 0.02} 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.095 0.04 0.04" />
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <visual>
+        <origin xyz="${BODY_X/2 - 0.0519} ${- BODY_Y/2 + 0.02} 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.095 0.04 0.04" />
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <visual>
+        <origin xyz="${- BODY_X/2 + 0.0475} ${BODY_Y/2 - 0.02} 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.095 0.04 0.04" />
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <visual>
+        <origin xyz="${- BODY_X/2 + 0.0475} ${- BODY_Y/2 + 0.02} 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.095 0.04 0.04" />
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <!-- wheel shaft -->
+      <visual>
+        <origin xyz="${BODY_X/2 - 0.0519} ${WHEEL_BIAS/2 - WHEEL_WIDTH/2 - 0.0255} 0" rpy="${M_PI/2} 0 0" />
+        <geometry>
+          <cylinder length="0.051" radius="0.004"/>
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <visual>
+        <origin xyz="${BODY_X/2 - 0.0519} ${- WHEEL_BIAS/2 + WHEEL_WIDTH/2 + 0.0255} 0" rpy="${M_PI/2} 0 0" />
+        <geometry>
+          <cylinder length="0.051" radius="0.004"/>
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <visual>
+        <origin xyz="${- BODY_X/2 + 0.0475} ${FREEWHEEL_BIAS/2 - OMNI_WIDTH/2 - 0.0255} 0" rpy="${M_PI/2} 0 0" />
+        <geometry>
+          <cylinder length="0.051" radius="0.012"/>
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+      <visual>
+        <origin xyz="${- BODY_X/2 + 0.0475} ${- FREEWHEEL_BIAS/2 + OMNI_WIDTH/2 + 0.0255} 0" rpy="${M_PI/2} 0 0" />
+        <geometry>
+          <cylinder length="0.051" radius="0.012"/>
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+    </link>
+
+    <xacro:macro name="wheel" params="name xyz rpy">
+      <link name="${name}_link">
+        <inertial>
+          <origin xyz="0 0 0.01" rpy="0 0 0" />
+          <mass value="0.2" />
+          <inertia ixx="0.00048667" ixy="0" ixz="0" iyy="0.00048667" iyz="0" izz="0.00081" />
+        </inertial>
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <cylinder length="${WHEEL_WIDTH}" radius="${WHEEL_RADIUS}"/>
+          </geometry>
+          <xacro:black_material/>
+        </visual>
+        <collision>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <cylinder length="${WHEEL_WIDTH}" radius="${WHEEL_RADIUS}"/>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="${name}_joint" type="continuous">
+        <origin xyz="${xyz}" rpy="${rpy}" />
+        <parent link="base_control_shift" />
+        <child link="${name}_link" />
+        <axis xyz="0 0 1" />
+        <limit effort="0" velocity="1.0" />
+      </joint>
+    </xacro:macro>
+
+    <xacro:if value="${sim}">
+      <xacro:wheel name="awl" xyz="0 ${WHEEL_BIAS/2} 0" rpy="${-M_PI/2} 0 0"/>
+      <!--wheel_diameter/2-->
+      <xacro:wheel name="awr" xyz="0 ${-WHEEL_BIAS/2} 0" rpy="${-M_PI/2} 0 0"/>
+      <!--wheel_diameter/2-->
+    </xacro:if>
+
+    <xacro:macro name="free_wheel" params="name xyz">
+      <link name="${name}_link">
+        <inertial>
+          <origin xyz="0 0 0.01" rpy="0 0 0" />
+          <mass value="0.2" />
+          <inertia ixx="0.00048667" ixy="0" ixz="0" iyy="0.00048667" iyz="0" izz="0.00081" />
+        </inertial>
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <cylinder length="${OMNI_WIDTH}" radius="${OMNI_RADIUS}"/>
+          </geometry>
+          <xacro:black_material/>
+        </visual>
+
+        <collision>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <cylinder length="${OMNI_WIDTH}" radius="${OMNI_RADIUS}"/>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="${name}_joint" type="fixed">
+        <origin xyz="${xyz}" rpy="0 ${-M_PI/2} ${M_PI/2}" />
+        <parent link="base_link" />
+        <child link="${name}_link" />
+        <axis xyz="1 0 0" />
+      </joint>
+    </xacro:macro>
+
+    <xacro:free_wheel name="pw2" xyz="${-BODY_X/2 + 0.0475} ${FREEWHEEL_BIAS/2} 0.0"/>
+    <xacro:free_wheel name="pw4" xyz="${-BODY_X/2 + 0.0475} ${-FREEWHEEL_BIAS/2} 0.0"/>
+
+    <link name="handle_link">
+      <inertial>
+        <origin xyz="-4.3092E-17 0.26035 0.01" rpy="0 0 0" />
+        <mass value="0.4228" />
+        <inertia ixx="0.0091197" ixy="2.2522E-18" ixz="4.8405E-20" iyy="0.0016715" iyz="1.0605E-19" izz="0.010763" />
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <mesh scale="1.0 1.0 0.75" filename="package://cabot_description/meshes/handle_Link.STL" />
+        </geometry>
+
+        <xacro:gold_material/>
+
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <mesh scale="1.0 1.0 0.75" filename="package://cabot_description/meshes/handle_Link.STL" />
+        </geometry>
+      </collision>
+    </link>
+
+    <link name="glip_link">
+      <inertial>
+        <origin xyz="-4.3092E-17 0.26035 0.01" rpy="0 0 0" />
+        <mass value="0.1228" />
+        <inertia ixx="0.0091197" ixy="2.2522E-18" ixz="4.8405E-20" iyy="0.0016715" iyz="1.0605E-19" izz="0.010763" />
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 ${M_PI/2} 0" />
+        <geometry>
+          <cylinder length="0.16" radius="0.014"/>
+        </geometry>
+        <xacro:black_material/>
+      </visual>
+    </link>
+
+
+    <joint name="handle_joint" type="fixed">
+      <origin xyz="0 ${-BODY_Y/2+0.02} ${BODY_Z + CLEARANCE - WHEEL_RADIUS - 0.0815} " rpy="${M_PI/2} 0 0" />
+      <parent link="base_link" />
+      <child link="handle_link" />
+      <axis xyz="0 0 0" />
+    </joint>
+
+    <joint name="glip_joint" type="fixed">
+      <origin xyz="0 ${-BODY_Y/2+0.0125} ${BODY_Z + CLEARANCE - WHEEL_RADIUS + 0.382} " rpy="0 0 0" />
+      <parent link="base_link" />
+      <child link="glip_link" />
+      <axis xyz="0 0 0" />
+    </joint> name="glip_joing" 
+    
+    <xacro:macro name="sensor_base" params="name xyz">
+      <link name="${name}_link">
+        <inertial>
+          <origin xyz="0 0.067278 0.011611" rpy="0 0 0" />
+          <mass value="0.1383" />
+          <inertia ixx="0.00047241" ixy="3.7914E-19" ixz="-1.6873E-19" iyy="0.00023852" iyz="5.537E-05" izz="0.00067032" />
+        </inertial>
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <mesh filename="package://cabot_description/meshes/s1_Link.STL" />
+          </geometry>
+
+          <xacro:black_material/>
+
+        </visual>
+      </link>
+      <joint name="${name}_joint" type="fixed">
+        <origin xyz="${xyz}" rpy="${M_PI} 0 ${M_PI}" />
+        <parent link="base_link" />
+        <child link="${name}_link" />
+        <axis xyz="0 0 0" />
+      </joint>
+    </xacro:macro>
+
+    <!--
+	<sensor_base name="s1" xyz="0 -0.135 0.72"/>
+	<sensor_base name="s2" xyz="0 0.156 0.5"/>
+    -->
+
+
+  </xacro:macro>
+</robot>

--- a/cabot_description/urdf/cabot2-gtm-outdoor_description.urdf
+++ b/cabot_description/urdf/cabot2-gtm-outdoor_description.urdf
@@ -148,7 +148,8 @@ THE SOFTWARE. -->
     -->
 
     <joint name="imu_joint" type="fixed">
-      <origin xyz="0.01 0.00 0.38" rpy="0 0 0" />
+      <!-- origin xyz="0.01 0.00 0.38" rpy="0 0 0" /--> <!-- measured imu box position -->
+      <origin xyz="0.01 0.00 0.0" rpy="0 0 0" /> <!-- imu_base z position is shifted to base_link to keep it low.-->
       <parent link="base_link"/>
       <child link="imu_frame" />
     </joint>

--- a/cabot_description/urdf/cabot2-gtm-outdoor_description.urdf
+++ b/cabot_description/urdf/cabot2-gtm-outdoor_description.urdf
@@ -43,11 +43,11 @@ THE SOFTWARE. -->
         <publishTf>1</publishTf>
         <publishOdomTF>true</publishOdomTF>
         <publishWheelJointState>true</publishWheelJointState>
-        <updateRate>10.0</updateRate>
+        <updateRate>20.0</updateRate>
         <leftJoint>awl_joint</leftJoint>
         <rightJoint>awr_joint</rightJoint>
-        <wheelSeparation>0.210</wheelSeparation>
-        <wheelDiameter>0.073</wheelDiameter>
+        <wheelSeparation>0.264</wheelSeparation>
+        <wheelDiameter>0.20</wheelDiameter>
         <wheelAcceleration>1.0</wheelAcceleration>
         <wheelTorque>20</wheelTorque>
         <commandTopic>/cabot/cmd_vel</commandTopic>
@@ -128,7 +128,12 @@ THE SOFTWARE. -->
     </joint>
 
     <joint name="control_center_joint" type="fixed">
+      <!-- front drive -->
+      <!--
       <origin xyz="${-BODY_X/2 + 0.0519} 0 0" rpy="0 0 0" />
+      -->
+      <!-- rear drive -->
+      <origin xyz="${BODY_X/2 - 0.0519} 0 0" rpy="0 0 0" />
       <parent link="base_control_shift"/>
       <child link="base_link" />
     </joint>
@@ -237,6 +242,7 @@ THE SOFTWARE. -->
       </visual>
     </link>
 
+    <!-- wheel -->
     <xacro:macro name="wheel" params="name xyz rpy">
       <link name="${name}_link">
         <inertial>
@@ -274,6 +280,8 @@ THE SOFTWARE. -->
       <!--wheel_diameter/2-->
     </xacro:if>
 
+    <!-- free wheel -->
+    <!-- for visualization -->
     <xacro:macro name="free_wheel" params="name xyz">
       <link name="${name}_link">
         <inertial>
@@ -288,13 +296,14 @@ THE SOFTWARE. -->
           </geometry>
           <xacro:black_material/>
         </visual>
-
+        <!--
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
             <cylinder length="${OMNI_WIDTH}" radius="${OMNI_RADIUS}"/>
           </geometry>
         </collision>
+        -->
       </link>
       <joint name="${name}_joint" type="fixed">
         <origin xyz="${xyz}" rpy="0 ${-M_PI/2} ${M_PI/2}" />
@@ -304,8 +313,57 @@ THE SOFTWARE. -->
       </joint>
     </xacro:macro>
 
+    <!-- front drive -->
+    <!--
     <xacro:free_wheel name="pw2" xyz="${-BODY_X/2 + 0.0475} ${FREEWHEEL_BIAS/2} 0.0"/>
     <xacro:free_wheel name="pw4" xyz="${-BODY_X/2 + 0.0475} ${-FREEWHEEL_BIAS/2} 0.0"/>
+    -->
+    <!-- rear drive -->
+    <xacro:free_wheel name="pw2" xyz="${BODY_X/2 - 0.0475} ${FREEWHEEL_BIAS/2} 0.0"/>
+    <xacro:free_wheel name="pw4" xyz="${BODY_X/2 - 0.0475} ${-FREEWHEEL_BIAS/2} 0.0"/>
+
+    <!-- virtual caster -->
+    <!-- for simplified simulation instead of using precise passive wheel simulation -->
+    <xacro:macro name="virtual_caster" params="name xyz">
+      <link name="${name}_link">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <mass value="0.2" />
+          <inertia ixx="0.000162" ixy="0.0" ixz="0.0" iyy="0.000162" iyz="0.0" izz="0.000162" />
+        </inertial>
+        <!--
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <sphere radius="${WHEEL_RADIUS}"/>
+          </geometry>
+          <material name="">
+            <color rgba="0.79216 0.81961 0.93333 1" />
+          </material>
+        </visual>
+        -->
+        <collision>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <sphere radius="${WHEEL_RADIUS}"/>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="${name}_joint" type="fixed">
+        <origin xyz="${xyz}" rpy="0 0 0" />
+        <parent link="base_link" />
+        <child link="${name}_link" />
+        <axis xyz="1 0 0" />
+      </joint>
+    </xacro:macro>
+
+    <!-- front drive -->
+    <!--
+    <xacro:virtual_caster name="vc1" xyz="${-BODY_X/2 + WHEEL_RADIUS} 0 0"/>
+    -->
+    <!-- rear drive -->
+    <xacro:virtual_caster name="vc1" xyz="${BODY_X/2 - WHEEL_RADIUS} 0 0"/>
+
 
     <link name="handle_link">
       <inertial>

--- a/cabot_gazebo/launch/includes/cabot2-gtm-outdoor.launch.xml
+++ b/cabot_gazebo/launch/includes/cabot2-gtm-outdoor.launch.xml
@@ -1,0 +1,228 @@
+<!-- Copyright (c) 2020  Carnegie Mellon University
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. -->
+ 
+<launch>
+  <arg name="offset" default="0" />
+  <arg name="output" default="screen" />
+  <arg name="enable_touch" default="false"/>
+  <arg name="touch_params" default="[128,48,24]"/>
+  <arg name="use_arduino" default="true"/>
+  <arg name="use_speedlimit" default="true"/>
+  <!-- -->
+  
+  <!--
+  <node pkg="tf" type="static_transform_publisher" name="local_lidar_base"
+	args="0.02 0.0 0.58 0 0 1.57 1  local/base_link lidar_link  100"/>  
+  -->
+
+    <!--
+  Nodelet manager
+  This nodelet deals with odometry and sensors of CaBot1
+  - CaBot/SpeedVisualizeNodelet
+  - CaBot/CaBotESensorNodelet
+  - Safety/OdomAdapterNodelet
+  - Safety/LiDARSpeedControlNodelet
+  - Safety/SpeedControlNodelet
+    -->
+  <group ns="cabot">
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="cabot_nodelet_manager" args="manager"/>
+
+    <!-- visualize speed -->
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="speed_visualize_nodelet"
+    args="load CaBot/SpeedVisualizeNodelet cabot_nodelet_manager">
+      <param name="cmd_vel_topic" value="/cabot/cmd_vel"/>
+      <param name="visualize_topic" value="/cabot/poi"/>
+    </node>
+
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="cabot_e_sensor"
+	  args="load CaBot/CaBotESensorNodelet cabot_nodelet_manager">
+      <param name="sensor_topic" type="string" value="/cabot/wrench_dummy" />
+      <param name="event_topic" type="string" value="/cabot/event" />
+    </node>
+
+    <!-- Cabot Odometry Adapter -->
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="odom_adapter_nodelet"
+	  args="load Safety/OdomAdapterNodelet cabot_nodelet_manager">
+      <param name="odom_input" value="/odom_gazebo"/>
+      <param name="odom_output" value="/odom_"/>
+      <param name="odom_frame" value="odom"/>
+      <param name="base_frame" value="base_footprint"/>
+      <param name="offset_frame" value="base_control_shift"/>
+      <param name="publish_tf" value="false" />
+      <param name="max_speed" value="1.0" />
+      
+      <param name="cmd_vel_input" value="/cabot/cmd_vel_limited"/>
+      <param name="cmd_vel_output" value="/cabot/cmd_vel"/>
+      
+      <param name="target_rate" value="20"/>
+    </node>
+    
+    <!-- for local odom navigation-->
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="odom_adapter_nodelet2"
+	  args="load Safety/OdomAdapterNodelet cabot_nodelet_manager">
+      <param name="odom_input" value="/odom"/>
+      <param name="odom_output" value="/odom_"/>
+      <param name="odom_frame" value="local/odom"/>
+      <param name="base_frame" value="local/base_footprint"/>
+      <param name="offset_frame" value="local/base_footprint"/>
+      <param name="publish_tf" value="true" />
+      <param name="max_speed" value="1.0" />
+      
+      <param name="cmd_vel_input" value="/cabot/cmd_vel_limited_"/>
+      <param name="cmd_vel_output" value="/cabot/cmd_vel_"/>
+      
+      <param name="target_rate" value="20"/>
+    </node>
+    
+    <!--  Cabot Lidar Speed Control -->
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="cabot_e_lidar_speed"
+    args="load Safety/LiDARSpeedControlNodelet cabot_nodelet_manager" if="$(arg use_speedlimit)">
+      <param name="laser_topic" type="string" value="/scan" />
+      <param name="visualize_topic" type="string" value="visualize" />
+      <param name="limit_topic" type="string" value="/cabot/lidar_speed" />
+      <!-- ToDo(daisueks): make this true once bug is fixed -->
+      <param name="check_front_obstacle" type="bool" value="false" />
+    </node>
+
+    <!-- Cabot People SPeed Control -->
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="cabot_e_people_speed"
+	  args="load Safety/PeopleSpeedControlNodelet cabot_nodelet_manager" if="$(arg use_speedlimit)">
+      <param name="people_topic" type="string" value="/people" />
+      <param name="visualize_topic" type="string" value="/visualize" />
+      <param name="limit_topic" type="string" value="/cabot/people_speed" />
+      <param name="odom_topic" type="string" value="/odom" />
+      <param name="plan_topic" type="string" value="/plan" />
+      <param name="event_topic" type="string" value="/cabot/event" />
+      <param name="social_distance_x" value="2.00" />
+      <param name="social_distance_y" value="0.50" />
+    </node>
+
+    <!--  Cabot TF Speed Control -->
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="cabot_e_tf_speed"
+    args="load Safety/TFSpeedControlNodelet cabot_nodelet_manager" if="$(arg use_speedlimit)">
+      <param name="limit_topic" type="string" value="/cabot/tf_speed" />
+    </node>
+    
+    <!--
+	Cabot Speed Control
+	This node limit the speed from the move_base based on specified topics
+	  /cabot/user_speed  - control by user
+	  /cabot/lidar_speed - control by lidar sensor
+	  /cabot/map_speed   - control by map speed poi
+	  /cabot/touch_speed - control by touch sensor
+    -->
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="speed_control_nodelet"
+	  args="load Safety/SpeedControlNodelet cabot_nodelet_manager" if="$(arg use_speedlimit)">
+      <param name="cmd_vel_input" type="string" value="/cmd_vel" />
+      <param name="cmd_vel_output" type="string" value="/cabot/cmd_vel_limited" />
+
+      <param name="speed_input" type="yaml"
+       value="[/cabot/user_speed, /cabot/lidar_speed, /cabot/people_speed, /cabot/tf_speed, /cabot/queue_speed, /cabot/map_speed, /cabot/touch_speed_switched]" if="$(arg enable_touch)"/>
+      <param name="speed_input" type="yaml"
+       value="[/cabot/user_speed, /cabot/lidar_speed, /cabot/people_speed, /cabot/tf_speed, /cabot/queue_speed, /cabot/map_speed]" unless="$(arg enable_touch)"/>
+      <param name="speed_limit" type="yaml" value="[2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]"/>
+      <param name="speed_timeout" type="yaml" value="[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.5]"/>
+      <param name="complete_stop" type="yaml" value="[false,false,false,false,true,false,true]"/>
+      <param name="configurable" type="yaml" value="[true,false,false,false,false,false,false]"/>
+    </node>
+
+    <node pkg="nodelet" type="nodelet" output="$(arg output)" name="speed_control_nodelet"
+	  args="load Safety/SpeedControlNodelet cabot_nodelet_manager" unless="$(arg use_speedlimit)">
+      <param name="cmd_vel_input" type="string" value="/cmd_vel" />
+      <param name="cmd_vel_output" type="string" value="/cabot/cmd_vel_limited" />
+      <param name="speed_input" type="yaml" value="[]" />
+    </node>
+
+    <node pkg="cabot_ui" type="cabot_force.py" name="cabot_force" output="screen">
+    </node>
+    
+    <node pkg="cabot" type="cabot_serial.py" name="rosserial" output="screen" if="$(arg use_arduino)">
+      <param name="port" value="/dev/ttyARDUINO_MEGA"/>
+      <param name="baud" value="115200"/>
+      <param name="touch_params" type="yaml" value="$(arg touch_params)"/>
+      <param name="touch_speed_max_inactive" value="0.5"/>
+
+      <remap from="/cabot/touch_speed" to="/cabot/touch_speed_raw"/>
+    </node>
+
+    <!-- Haptic handle v2
+    <node pkg="cabot" type="cabot_serial.py" name="rosserial2" output="screen">
+      <param name="port" value="/dev/ttyVIB1"/>
+      <param name="baud" value="57600"/>
+    </node>
+    -->
+    <node pkg="cabot" type="cabot_handle_v2_node.py" name="cabot_handle_v2_node" output="screen">
+      <param name="no_vibration" value="false"/>
+    </node>
+
+    <node pkg="nodelet" type="nodelet" name="pointcloud_to_laserscan_node"
+          args="load pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet cabot_nodelet_manager">
+      
+      <remap from="cloud_in" to="/velodyne_points"/>
+      <remap from="scan" to="/scan"/>
+      <rosparam>
+target_frame: velodyne # Leave disabled to output scan in pointcloud frame
+transform_tolerance: 0.01
+min_height: -0.30 # origin is the sensor
+max_height: 1.4 # origin is the sensor
+angle_min: -2.57  # -M_PI/2 - 1.0 (angle clipping)
+angle_max: 1.57 # M_PI/2
+angle_increment: 0.00436 # M_PI/360/2
+scan_time: 0.1
+range_min: 0.2
+range_max: 50
+use_inf: true
+inf_epsilon: 1.0
+
+# Concurrency level, affects number of pointclouds queued for
+# processing and number of threads used
+# 0 : Detect number of cores
+# 1 : Single threaded
+# 2->inf : Parallelism level
+concurrency_level: 0
+      </rosparam>
+    </node>
+    
+  </group>
+
+  <!-- run pcl crop box filter node -->
+  <arg name="manager" default="velodyne_nodelet_manager"/>
+  <!-- start nodelet manager -->
+  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+  <!-- load pcl crop box node to the nodelet manager -->
+  <node pkg="nodelet" type="nodelet" name="pcl_crop_box_node"
+        args="load pcl/CropBox $(arg manager)" output="screen">
+    <remap from="~input" to="/velodyne_points" />
+    <remap from="~output" to="/velodyne_points_cropped" />
+    <!-- crop box where user can stand -->
+    <rosparam>
+      min_x: -0.7
+      min_y: -0.6
+      min_z: 0
+      max_x: 0.2
+      max_y: 0.1
+      max_z: 2
+      keep_organized: false
+      negative: true
+      input_frame: "base_link"
+      output_frame: "velodyne"
+    </rosparam>
+  </node>
+</launch>

--- a/cabot_navigation/param/cabot2-gtm-outdoor_footprint.yaml
+++ b/cabot_navigation/param/cabot2-gtm-outdoor_footprint.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2020  Carnegie Mellon University
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#footprint: [[-0.145, 0.115], [-0.145, -0.115], [0.145, -0.115], [0.145, 0.115]]
+#footprint_padding: 0.01
+robot_radius: 0.2
+
+TebLocalPlannerROS:
+
+  footprint_model: # types: "point", "circular", "line", "two_circles", "polygon"
+    type: "polygon"
+    
+    radius: 0.2 # for type "circular"
+    line_start: [0.0, 0.0] # for type "line"
+    line_end: [0.0, 0.3] # for type "line"
+    front_offset: 0.2 # for type "two_circles"
+    front_radius: 0.2 # for type "two_circles"
+    rear_offset: 0.2 # for type "two_circles"
+    rear_radius: 0.2 # for type "two_circles"
+
+    vertices: [[-0.145, 0.115], [-0.145, -0.115], [0.145, -0.115], [0.145, 0.115]]

--- a/cabot_navigation/param/cabot2-gtm-outdoor_human_footprint.yaml
+++ b/cabot_navigation/param/cabot2-gtm-outdoor_human_footprint.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2020  Carnegie Mellon University
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# needs to be configurable
+#footprint: [[-0.145, 0.415], [-0.145, -0.115], [0.145, -0.115], [0.145, 0.415]] 
+#footprint_padding: 0.01
+#robot_radius: 0.2
+robot_radius: 0.45
+
+TebLocalPlannerROS:
+
+  footprint_model: # types: "point", "circular", "line", "two_circles", "polygon"
+    type: "point"
+    
+    radius: 0.45
+    #radius: 0.2 # for type "circular"
+    line_start: [0.0, 0.0] # for type "line"
+    line_end: [0.0, 0.3] # for type "line"
+    front_offset: 0.2 # for type "two_circles"
+    front_radius: 0.2 # for type "two_circles"
+    rear_offset: 0.2 # for type "two_circles"
+    rear_radius: 0.2 # for type "two_circles"
+
+    vertices: [[-0.145, 0.265], [-0.145, -0.115], [0.145, -0.115], [0.145, 0.265]] 
+

--- a/mf_localization/src/multi_floor_manager.py
+++ b/mf_localization/src/multi_floor_manager.py
@@ -276,7 +276,7 @@ class MultiFloorManager:
 
         # for gnss localization
         # parameters
-        self.gnss_position_covariance_threshold = 0.1*0.1
+        self.gnss_position_covariance_threshold = 0.2*0.2
         self.gnss_track_error_threshold = 5.0
         self.gnss_track_yaw_threshold = np.radians(30)
         self.gnss_track_error_adjust = 0.1

--- a/mf_localization_mapping/urdf/cabot2-gtm-outdoor.urdf
+++ b/mf_localization_mapping/urdf/cabot2-gtm-outdoor.urdf
@@ -1,0 +1,68 @@
+<!--
+ Copyright (c) 2021  IBM Corporation
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+
+<robot name="cabot2-gtm">
+
+  <link name="base_link" />
+  <link name="velodyne" />
+  <link name="imu" />
+  <link name="imu_frame" />
+  <link name="imu_frame_xsens" />
+  <link name="imu_link" />
+  <link name="gps" />
+
+  <joint name="velodyne_joint" type="fixed">
+    <parent link="base_link" />
+    <child link="velodyne" />
+    <origin xyz="0.0 0.0 0.57" rpy="0.0 0.0 1.57"/>
+  </joint>
+
+  <joint name="imu_joint" type="fixed">
+    <parent link="base_link" />
+    <child link="imu" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+  </joint>
+
+  <joint name="imu_frame_joint" type="fixed">
+    <parent link="imu" />
+    <child link="imu_frame" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+  </joint>
+
+  <joint name="imu_frame_xsens_joint" type="fixed">
+    <parent link="imu" />
+    <child link="imu_frame_xsens" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+  </joint>
+
+  <joint name="imu_link_joint" type="fixed">
+    <parent link="imu" />
+    <child link="imu_link" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+  </joint>
+
+  <joint name="gps_joint" type="fixed">
+    <parent link="velodyne" />
+    <child link="gps" />
+    <origin xyz="0.0 0.0 0.1" rpy="0.0 0.0 -1.57"/>
+  </joint>
+</robot>

--- a/motor_controller/odriver/scripts/odriver_node.py
+++ b/motor_controller/odriver/scripts/odriver_node.py
@@ -73,6 +73,7 @@ use_checksum=False
 '''Configuarable parameter'''
 meter_per_count = None
 leftIs1 = False # left is axis0, right is axis1
+isClockwise = False
 signLeft = -1.0
 signRight = 1.0
 gainLeft = 1.0
@@ -337,15 +338,23 @@ def main():
     pub = rospy.Publisher('motorStatus', MotorStatus, queue_size=10)
 #    rospy.Subscriber('motorTarget', MotorTarget, MotorTargetRoutine, queue_size=10)
 
-    global meter_per_count, meter_per_round, leftIs1, signLeft, signRight, gainLeft, gainRight
+    global meter_per_count, meter_per_round, leftIs1, isClockwise, signLeft, signRight, gainLeft, gainRight
     global count_motorTarget, previous_count_motorTarget
     wheel_diameter = rospy.get_param("~wheel_diameter")
     count_per_round = rospy.get_param("~count_per_round")
     meter_per_count = wheel_diameter * np.pi / count_per_round
     meter_per_round = wheel_diameter * np.pi
     if rospy.has_param("~left_is_1"): leftIs1 = rospy.get_param("~left_is_1")
+    if rospy.has_param("~is_clockwise"): isClockwise = rospy.get_param("~is_clockwise")
     if rospy.has_param("~gain_left"): gainLeft = rospy.get_param("~gain_left")
     if rospy.has_param("~gain_right"): gainRight = rospy.get_param("~gain_right")
+    
+    if isClockwise:
+        signLeft = -1.0
+        signRight = 1.0
+    else:
+        signLeft = 1.0
+        signRight = -1.0
 
     vel_gain = rospy.get_param("~vel_gain", 1.0)
     vel_integrator_gain = rospy.get_param("~vel_integrator_gain", 10)

--- a/motor_controller/odriver/scripts/odriver_node.py
+++ b/motor_controller/odriver/scripts/odriver_node.py
@@ -106,9 +106,13 @@ def clear_errors(odrv):
     fw_version = version.parse(".".join(map(str,[odrv.fw_version_major, odrv.fw_version_minor, odrv.fw_version_revision])))
     if version.parse("0.5.2") <= fw_version:
         odrv.clear_errors()
-    else:
-        odrv.axis0.clear_errors()
-        odrv.axis1.clear_errors()
+    else: # fw_version <= 0.5.1
+        # The following try block throws an error when an odrv object returns a wrong version number due to a bug related to firmware.
+        try:
+            odrv.axis0.clear_errors()
+            odrv.axis1.clear_errors()
+        except AttributeError:
+            odrv.clear_errors()
 
 
 def find_controller(port, clear=False, reset_watchdog_error=False):

--- a/motor_controller/odriver/scripts/odriver_node.py
+++ b/motor_controller/odriver/scripts/odriver_node.py
@@ -73,7 +73,7 @@ use_checksum=False
 '''Configuarable parameter'''
 meter_per_count = None
 leftIs1 = False # left is axis0, right is axis1
-isClockwise = False
+isClockwise = True # set true if sign = 1 corresponds to the clockwise direction. set false if sign = 1 corresponds to the counter-clockwise direction.
 signLeft = -1.0
 signRight = 1.0
 gainLeft = 1.0
@@ -348,7 +348,7 @@ def main():
     if rospy.has_param("~is_clockwise"): isClockwise = rospy.get_param("~is_clockwise")
     if rospy.has_param("~gain_left"): gainLeft = rospy.get_param("~gain_left")
     if rospy.has_param("~gain_right"): gainRight = rospy.get_param("~gain_right")
-    
+
     if isClockwise:
         signLeft = -1.0
         signRight = 1.0


### PR DESCRIPTION
Major changes
- Add cabot2-gtm-outdoor config files (launch, xml, urdf etc.)

Minor changes
- Modify odriver_node.py for cabot2-gtm-outdoor
  - The default behavior does not change.
  - Add isClockWise parameter for a motor used in cabot2-gtm-outdoor
- Add vlp-16-front.launch.xml file and use it in cabot2-gtm and cabot2-gtm-outdoor to fix an issue caused by the wrong lidar configuration.
- Slightly change a parameter value in multi_floor_manager in mf_localization