### PR TITLE
Add a function to disable motor control by holding down a handle button

### DIFF
--- a/cabot/launch/cabot2-ace.launch
+++ b/cabot/launch/cabot2-ace.launch
@@ -351,6 +351,8 @@ THE SOFTWARE. -->
       <param name="motor_topic" type="string" value="/cabot/motorTarget" />
       <param name="cmd_vel_topic" type="string" value="/cabot/cmd_vel" />
 
+      <param name="pause_control_topic" type="string" value="/cabot/pause_control"/>
+
       <param name="max_acc" value="1.2"/>
       <param name="target_rate" value="20"/>
       <param name="bias" value="0.23"/> <!--wheel separation-->

--- a/cabot/python/cabot/event.py
+++ b/cabot/python/cabot/event.py
@@ -139,6 +139,34 @@ class ClickEvent(BaseEvent):
             return cls(buttons=buttons, count=count)
         return None
 
+
+class HoldDownEvent(BaseEvent):
+    TYPE="holddown"
+    def __init__(self, type=None, holddown=0):
+        type = type if type is not None else HoldDownEvent.TYPE
+        super(HoldDownEvent, self).__init__(type=type)
+        self._holddown = holddown
+
+    def __eq__(self, other):
+        return self.type == other.type \
+            and self.holddown == other.holddown
+
+    @property
+    def holddown(self):
+        return self._holddown
+
+    def __str__(self):
+        return "%s_%d" % (self.type, self.holddown)
+
+    @classmethod
+    def _parse(cls, text):
+        if text.startswith(cls.TYPE):
+            items = text.split("_")
+            holddown = int(items[1])
+            return cls(holddown=holddown)
+        return None
+
+
 class JoyClickEvent(ClickEvent):
     TYPE="joyclick"
     def __init__(self, buttons=0, count=0):

--- a/cabot/python/cabot/handle_v2.py
+++ b/cabot/python/cabot/handle_v2.py
@@ -35,8 +35,9 @@ class Handle:
     LEFT_ABOUT_TURN = 6
     RIGHT_ABOUT_TURN = 7
     BUTTON_CLICK = 8
-    STIMULI_COUNT = 9
-    stimuli_names = ["unknown", "left_turn", "right_turn", "left_dev", "right_dev", "front", "left_about_turn", "right_about_turn", "button_click"]
+    BUTTON_HOLDDOWN = 9
+    STIMULI_COUNT = 10
+    stimuli_names = ["unknown", "left_turn", "right_turn", "left_dev", "right_dev", "front", "left_about_turn", "right_about_turn", "button_click", "button_holddown"]
 
     @staticmethod
     def get_name(stimulus):
@@ -47,6 +48,7 @@ class Handle:
         self.button_keys = button_keys
         self.number_of_buttons = len(button_keys)
         self.lastUp = [None]*self.number_of_buttons
+        self.lastDwn = [None]*self.number_of_buttons
         self.upCount = [0]*self.number_of_buttons
         self.btnDwn = [False]*self.number_of_buttons
         self.power = 255
@@ -61,6 +63,7 @@ class Handle:
         self.duration_single_vibration = 40
         self.duration_about_turn = 40
         self.duration_button_click = 5
+        self.duration_button_holddown = 10 # [ms] ?
         self.sleep = 150
         self.updown = True
         self.num_vibrations_turn = 4
@@ -68,6 +71,7 @@ class Handle:
         self.num_vibrations_about_turn = 2
         self.num_vibrations_confirmation = 1
         self.num_vibrations_button_click = 1
+        self.num_vibrations_button_holddown = 1
 
         self.callbacks = [None]*Handle.STIMULI_COUNT
         self.callbacks[Handle.LEFT_TURN] = self.vibrate_left_turn
@@ -78,34 +82,49 @@ class Handle:
         self.callbacks[Handle.LEFT_ABOUT_TURN] = self.vibrate_about_left_turn
         self.callbacks[Handle.RIGHT_ABOUT_TURN] = self.vibrate_about_right_turn
         self.callbacks[Handle.BUTTON_CLICK] = self.vibrate_button_click
+        self.callbacks[Handle.BUTTON_HOLDDOWN] = self.vibrate_button_holddown
 
         self.eventSub = rospy.Subscriber('/cabot/event', String, self.event_callback)
 
     double_click_interval = 0.25
     ignore_interval = 0.05
+    holddown_interval = 3.0 # [seconds]
     def button_callback(self, msg, index):
         self._button_check(msg, button.__dict__[self.button_keys[index]["value"]], index)
 
     def _button_check(self, msg, key, index):
         event = None
         now = rospy.get_rostime().to_sec()
+        # detect change from button up to button down to emit a button down event
         if msg.data and not self.btnDwn[index] and \
            not (self.lastUp[index] is not None and \
            now - self.lastUp[index] < self.ignore_interval):
             event = {"button":key, "up":False}
             self.btnDwn[index] = True
+            self.lastDwn[index] = now # for holddown detection
+        # detect change from button down to button up to emit a button up event
         if not msg.data and self.btnDwn[index]:
             event = {"button":key, "up":True}
             self.upCount[index] += 1
             self.lastUp[index] = now
             self.btnDwn[index] = False
+        # detect the end of a series of button down/up events to emit a click event
         if self.lastUp[index] is not None and \
            not self.btnDwn[index] and \
            now - self.lastUp[index] > self.double_click_interval:
-            event = {"buttons":key, "count":self.upCount[index]}
+            # emit click event only if a hold down event is not detected
+            if self.lastDwn[index] is not None:
+                event = {"buttons":key, "count":self.upCount[index]}
             self.lastUp[index] = None
             self.upCount[index] = 0
-            
+        # detect button hold down to emit a holddown event
+        if msg.data and self.btnDwn[index] and \
+           (self.lastDwn[index] is not None and \
+           now - self.lastDwn[index] > self.holddown_interval):
+            event = {"holddown":key}
+            # clear lastDwn[index] after holddown event emission to prevent multiple event emissions
+            self.lastDwn[index] = None
+
         if event is not None:
             if self.event_listener is not None:
                 self.event_listener(event)
@@ -195,6 +214,9 @@ class Handle:
 
     def vibrate_button_click(self):
         self.vibrate_pattern(self.vibrator1_pub, self.num_vibrations_button_click, self.duration_button_click)
+
+    def vibrate_button_holddown(self):
+        self.vibrate_pattern(self.vibrator1_pub, self.num_vibrations_button_holddown, self.duration_button_holddown)
 
     def vibrate_pattern(self, vibrator_pub, number_vibrations, duration):
         i=0

--- a/cabot/python/cabot_handle_v2_node.py
+++ b/cabot/python/cabot_handle_v2_node.py
@@ -45,6 +45,11 @@ def event_listener(msg):
     if "buttons" in msg:
         event = cabot.event.ClickEvent(**msg)
 
+    if "holddown" in msg:
+        event = cabot.event.HoldDownEvent(**msg)
+        # button hold down confirmation
+        handle.execute_stimulus(Handle.BUTTON_HOLDDOWN)
+
     if event is not None:
         rospy.loginfo(event)
         msg = std_msgs.msg.String()

--- a/cabot_ui/i18n/en.yaml
+++ b/cabot_ui/i18n/en.yaml
@@ -22,6 +22,7 @@
 MAIN_MENU: "Main Menu"
 I_AM_READY: "I'm ready"
 PAUSE_NAVIGATION: "pause navigation, push right button to resume."
+PAUSE_CONTROL: "pause autonomous navigation, push right button to resume."
 CANCEL_NAVIGATION: "cancel navigation"
 RESUME_NAVIGATION: "resume navigation"
 START_EXPLORATION: "exploration started"

--- a/cabot_ui/i18n/ja.yaml
+++ b/cabot_ui/i18n/ja.yaml
@@ -22,6 +22,7 @@
 MAIN_MENU: "メインメニュー"
 I_AM_READY: "準備ができました"
 PAUSE_NAVIGATION: "一時停止します。右ボタンで再開します。"
+PAUSE_CONTROL: "自動走行を停止します。右ボタンで再開します。"
 CANCEL_NAVIGATION: "終了します。"
 RESUME_NAVIGATION: "再開します。"
 START_EXPLORATION: "探索モードを開始します。"

--- a/cabot_ui/src/cabot_ui/interface.py
+++ b/cabot_ui/src/cabot_ui/interface.py
@@ -260,6 +260,11 @@ class UserInterface(object):
             self.speak(i18n.localized_string(message))
             self.last_social_announce = rospy.Time.now()
 
+    def set_pause_control(self, flag):
+        self._activity_log("cabot/interface", "pause_control", str(flag))
+        if flag:
+            self.speak(i18n.localized_string("PAUSE_CONTROL"))
+
     def please_call_elevator(self, pos):
         self._activity_log("cabot/interface", "navigation", "elevator button")
         if pos:

--- a/cabot_ui/src/cabot_ui/navigation.py
+++ b/cabot_ui/src/cabot_ui/navigation.py
@@ -915,6 +915,8 @@ class Navigation(ControlBase, navgoal.GoalInterface):
         callback(GoalStatus.SUCCEEDED, None)
 
     def set_pause_control(self, flag):
+        rospy.loginfo("navigation.{} called".format(util.callee_name()))
+        self.delegate.activity_log("cabot/navigation", "pause_control", str(flag))
         self.pause_control_state = flag
         self.pause_control_pub.publish(self.pause_control_state)
         if self.pause_control_loop_handler is None:


### PR DESCRIPTION
Added sub functions
- cabot_handle_v2 node sends a HoldDownEvent when a handle button is held down for more than 3 seconds. After the HoldDownEvent, the node does not send a ClickEvent even if the button is released to prevent sending different types of events.
- disable motor control if cabot_ui_manager receives a hold down event of the left button and enable motor control if it receives a click event of the right button.