### PR TITLE
simpify the map_list configuration file loaded by mf_localization

### DIFF
--- a/mf_localization/src/multi_floor_manager.py
+++ b/mf_localization/src/multi_floor_manager.py
@@ -1639,6 +1639,42 @@ class CartographerParameterConverter:
         return self.parameter_dict.get(node_id).get(str(mode))
 
 
+def extend_node_parameter_dictionary(all_params: dict) -> dict:
+    """If specific parameters are undefined, calculate and add them to the parameter dictionary."""
+    all_params_new = all_params.copy()
+
+    map_list = all_params_new.get("map_list")
+    floor_count = {}  # count floor for assigning area
+    for map_dict in map_list:
+        # read floor
+        floor = float(map_dict["floor"])
+        floor_str = str(int(map_dict["floor"]))
+        floor_count.setdefault(floor, 0)
+
+        # automatically assign area if undefined
+        area = int(map_dict["area"]) if "area" in map_dict else None
+        if area is None:
+            area = floor_count[floor]
+            map_dict["area"] = area
+        floor_count[floor] += 1
+        area_str = str(area)
+
+        # automatically assign node_id if undefined
+        node_id = map_dict["node_id"] if "node_id" in map_dict else None
+        if node_id is None:
+            node_id = "carto_"+floor_str+"_"+area_str
+            map_dict["node_id"] = node_id
+
+        # automatically assign floor_id if undefined
+        frame_id = map_dict["frame_id"] if "frame_id" in map_dict else None
+        if frame_id is None:
+            frame_id = "map_"+node_id
+            map_dict["frame_id"] = frame_id
+
+    all_params_new["map_list"] = map_list
+    return all_params_new
+
+
 if __name__ == "__main__":
     rospy.init_node('multi_floor_manager')
     launch = roslaunch.scriptapi.ROSLaunch()
@@ -1731,10 +1767,12 @@ if __name__ == "__main__":
         rssi_offset = rospy.get_param("~rssi_offset")
     rospy.loginfo("rssi_offset="+str(rssi_offset))
 
+    # extend parameter dictionary
+    all_params = extend_node_parameter_dictionary(all_params)
 
     # load the main anchor point
-    anchor_dict = rospy.get_param("~anchor")
-    map_list = rospy.get_param("~map_list")
+    anchor_dict = all_params.get("anchor")
+    map_list = all_params.get("map_list")
 
     modes = [LocalizationMode.INIT , LocalizationMode.TRACK]
 

--- a/mf_localization/src/multi_floor_map_server.py
+++ b/mf_localization/src/multi_floor_map_server.py
@@ -31,6 +31,8 @@ from nav_msgs.msg import OccupancyGrid
 
 import resource_utils
 
+from multi_floor_manager import extend_node_parameter_dictionary
+
 class CurrentMapTopicRemapper:
     def __init__(self, local_map_frame, global_map_frame, frame_id_list):
         self.local_map_frame = local_map_frame
@@ -68,7 +70,10 @@ def main():
     launch = roslaunch.scriptapi.ROSLaunch()
     launch.start()
 
-    map_list = rospy.get_param("~map_list")
+    all_params = rospy.get_param("~")
+    all_params = extend_node_parameter_dictionary(all_params)
+
+    map_list = all_params.get("map_list")
     local_map_frame = rospy.get_param("~local_map_frame", "map")
     global_map_frame = rospy.get_param("~global_map_frame", "map")
     publish_map_topic = rospy.get_param("~publish_map_topic", True)


### PR DESCRIPTION
This change makes some parameters in map config in cabot_site not required because these parameters can be set by using other parameters.

```
anchor:
    ...
map_list:
  - node_id: # not required (set as the default value "carto_" + floor + "_" + area)
    frame_id: # not required (set as the default value "map_" + node_id)
    latitude: 
    longitude: 
    rotate:
    floor:
    area: 0 # not required (calculated from floor)
    load_state_filename:
    samples_filename:
    map_filename:
```