### PR TITLE
update github actions to avoid unnecessary disk and network usage

### DIFF
--- a/.github/workflows/build-docker-image-schedule.yaml
+++ b/.github/workflows/build-docker-image-schedule.yaml
@@ -17,7 +17,8 @@ jobs:
       run: pip3 install vcstool
 
     - name: Prepare thirdparty repos
-      run: tools/setup-thirdparty-repos.sh
+      working-directory: docker
+      run: vcs import < thirdparty.repos
 
     - name: Prebuild images
       run: ./prebuild-docker.sh cuda
@@ -51,7 +52,8 @@ jobs:
       run: pip3 install vcstool
 
     - name: Prepare thirdparty repos
-      run: tools/setup-thirdparty-repos.sh
+      working-directory: docker
+      run: vcs import < thirdparty.repos
 
     - name: Prebuild images
       run: ./prebuild-docker.sh ros1
@@ -85,7 +87,8 @@ jobs:
       run: pip3 install vcstool
 
     - name: Prepare thirdparty repos
-      run: tools/setup-thirdparty-repos.sh
+      working-directory: docker
+      run: vcs import < thirdparty.repos
 
     - name: Prebuild images
       run: ./prebuild-docker.sh ros2

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -24,7 +24,8 @@ jobs:
       run: pip3 install vcstool
 
     - name: Prepare thirdparty repos
-      run: tools/setup-thirdparty-repos.sh
+      working-directory: docker
+      run: vcs import < thirdparty.repos
 
     - name: Prebuild images
       run: ./prebuild-docker.sh cuda
@@ -58,7 +59,8 @@ jobs:
       run: pip3 install vcstool
 
     - name: Prepare thirdparty repos
-      run: tools/setup-thirdparty-repos.sh
+      working-directory: docker
+      run: vcs import < thirdparty.repos
 
     - name: Prebuild images
       run: ./prebuild-docker.sh ros1
@@ -92,7 +94,8 @@ jobs:
       run: pip3 install vcstool
 
     - name: Prepare thirdparty repos
-      run: tools/setup-thirdparty-repos.sh
+      working-directory: docker
+      run: vcs import < thirdparty.repos
 
     - name: Prebuild images
       run: ./prebuild-docker.sh ros2


### PR DESCRIPTION
replaced
```
    - name: Prepare thirdparty repos
      run: tools/setup-thirdparty-repos.sh
```
to

```
    - name: Prepare thirdparty repos
      working-directory: docker
      run: vcs import < thirdparty.repos
```
in github actions because setup-thirdparty-repos.sh imports a repository with a large file size.
It will reduce disk and network usage and time to build images.