### PR TITLE
update CABOT_PRESURE_AVAILABLE for barometer available models

### DIFF
--- a/docker-compose-nuc-production.yaml
+++ b/docker-compose-nuc-production.yaml
@@ -39,7 +39,7 @@ services:
       service: localization
     environment:
       - CABOT_GAZEBO=0
-      - CABOT_PRESSURE_AVAILABLE=1
+      - CABOT_PRESSURE_AVAILABLE=${CABOT_PRESSURE_AVAILABLE:-1}
 
   people-nuc:
     extends:

--- a/docker-compose-nuc-production.yaml
+++ b/docker-compose-nuc-production.yaml
@@ -39,7 +39,7 @@ services:
       service: localization
     environment:
       - CABOT_GAZEBO=0
-      - CABOT_PRESSURE_AVAILABLE=0
+      - CABOT_PRESSURE_AVAILABLE=1
 
   people-nuc:
     extends:

--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -39,7 +39,7 @@ services:
       service: localization
     environment:
       - CABOT_GAZEBO=0
-      - CABOT_PRESSURE_AVAILABLE=0
+      - CABOT_PRESSURE_AVAILABLE=${CABOT_PRESSURE_AVAILABLE:-0}
 
   people:
     extends:

--- a/docker-compose-rs3-production.yaml
+++ b/docker-compose-rs3-production.yaml
@@ -39,7 +39,7 @@ services:
       service: localization
     environment:
       - CABOT_GAZEBO=0
-      - CABOT_PRESSURE_AVAILABLE=1
+      - CABOT_PRESSURE_AVAILABLE=${CABOT_PRESSURE_AVAILABLE:-1}
 
 # people service only queue and tracking
   people-nuc:

--- a/docker-compose-rs3-production.yaml
+++ b/docker-compose-rs3-production.yaml
@@ -39,7 +39,7 @@ services:
       service: localization
     environment:
       - CABOT_GAZEBO=0
-      - CABOT_PRESSURE_AVAILABLE=0
+      - CABOT_PRESSURE_AVAILABLE=1
 
 # people service only queue and tracking
   people-nuc:


### PR DESCRIPTION
updated the default value CABOT_PRESSURE_AVAILABLE for barometer available models (nuc and rs3) because it is better to avoid false positive of floor change detection for now.

also updated CABOT_PRESSURE_AVAILABLE to be configurable in .env file