### PR TITLE
Bugfix: localization does not start if services are not ready

### DIFF
--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -1046,7 +1046,9 @@ class MultiFloorManager:
         # try to finish the current trajectory
         floor_manager: FloorManager = self.ble_localizer_dict[self.floor][self.area][self.mode]
         get_trajectory_states = floor_manager.get_trajectory_states
+        get_trajectory_states.wait_for_service()
         finish_trajectory = floor_manager.finish_trajectory
+        finish_trajectory.wait_for_service()
         req = GetTrajectoryStates.Request()
         res0 = get_trajectory_states.call(req)
         self.logger.info(F"{res0}")
@@ -1071,6 +1073,7 @@ class MultiFloorManager:
 
         floor_manager: FloorManager = self.ble_localizer_dict[self.floor][self.area][self.mode]
         start_trajectory = floor_manager.start_trajectory
+        start_trajectory.wait_for_service()
 
         # start trajectory
         configuration_directory = floor_manager.configuration_directory
@@ -2193,10 +2196,6 @@ if __name__ == "__main__":
             floor_manager.get_trajectory_states = node.create_client(GetTrajectoryStates, node_id+"/"+str(mode)+'/get_trajectory_states', callback_group=MutuallyExclusiveCallbackGroup())
             floor_manager.finish_trajectory = node.create_client(FinishTrajectory, node_id+"/"+str(mode)+'/finish_trajectory', callback_group=MutuallyExclusiveCallbackGroup())
             floor_manager.start_trajectory = node.create_client(StartTrajectory, node_id+"/"+str(mode)+'/start_trajectory', callback_group=MutuallyExclusiveCallbackGroup())
-            # TODO(daisukes): this needs async run with loop
-            # floor_manager.get_trajectory_states.wait_for_service()
-            # floor_manager.finish_trajectory.wait_for_service()
-            # floor_manager.start_trajectory.wait_for_service()
 
     multi_floor_manager.floor_list = list(floor_set)
 


### PR DESCRIPTION
I could reproduce the issue by waiting 10 secs to launch cartographer nodes.

```
    # execute launch task
    launch_task = loop.create_task(launch_service.run_async())
```

```
    # execute launch task
    async def dummy_wait():
        import asyncio
        await asyncio.sleep(10)
        await launch_service.run_async())
        
    launch_task = loop.create_task(dummy_wait())
```

The system needs to wait for services before using them.
We can have a situation where the service is unavailable when the cartographer is dead, but that is a rare case and may be difficult to fix.
So, just wait forever.