### PR TITLE
Bugfix: fix local navigation config to use CabotSimpleGoalChecker

### DIFF
--- a/cabot_navigation2/params/nav2_params2.yaml
+++ b/cabot_navigation2/params/nav2_params2.yaml
@@ -86,7 +86,7 @@ controller_server:
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
     progress_checker_plugin: "progress_checker"
-    goal_checker_plugin: "cabot_goal_checker"
+    goal_checker_plugins: ["cabot_goal_checker"]
     controller_plugins: ["FollowPath"]
 
     # Progress checker parameters


### PR DESCRIPTION
The local navigation mode uses the default goal checker (SimpleGoalChecker) instead of CabotSimpleGoalChecker because the config file (nav2_params2.yaml) was not correctly migrated from Foxy to newer versions.
It is necessary to update `goal_checker_plugins` parameter for Galactic and newer versions.

https://navigation.ros.org/migration/Foxy.html#followpath-goal-checker-id-attribute