### PR TITLE
Fix bug, detect_obstacle_on_path node stops

### DIFF
--- a/track_people_cpp/src/detect_obstacle_on_path.cpp
+++ b/track_people_cpp/src/detect_obstacle_on_path.cpp
@@ -73,7 +73,7 @@ void DetectObstacleOnPath::update()
   boxes.header.frame_id = map_frame_name_;
   boxes.header.stamp = last_scan_->header.stamp;
 
-  if (last_plan_ == nullptr || last_scan_ == nullptr) {
+  if (last_plan_ == nullptr || last_scan_ == nullptr || idx_ == nullptr) {
     obstacle_freq_->tick();
     obstacle_pub_->publish(boxes);
     return;


### PR DESCRIPTION
This pull request fixes bug that detect_obstacle_on_path node stops with following error if LiDAR sensor message has future timestamp.
```
1695346870.4564946 [detect_obstacle_on_path_node-1] [ERROR] [1695346870.455646166] [obstacle.detect_obstacle_on_path]: extra ploration error Lookup would require extrapolation into the future.  Requested time 1695346869.155576 but the latest data is at time 1695346869.155576, when looking up transform from frame [velodyne] to frame [map]
1695346870.4572666 [detect_obstacle_on_path_node-1] [INFO] [1695346870.455836918] [obstacle.detect_obstacle_on_path]: update()
1695346870.4574866 [detect_obstacle_on_path_node-1] [INFO] [1695346870.455906770] [obstacle.detect_obstacle_on_path]: last_pose_index_=164 robot=(5.90,-0.07), plan_pose=(5.92,-0.17)
1695346870.5503888 [ERROR] [detect_obstacle_on_path_node-1]: process has died [pid 86, exit code -11, cmd '/home/developer/people_nuc_ws/install/track_people_cpp/lib/track_people_cpp/detect_obstacle_on_path_node --ros-args -r __node:=detect_obstacle_on_path -r __ns:=/obstacle'].
```

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>