### PR TITLE
vibration message behavior change

### DIFF
--- a/cabot/cabot/handle_v2.py
+++ b/cabot/cabot/handle_v2.py
@@ -236,19 +236,40 @@ class Handle:
 
     def vibrate_pattern(self, vibrator_pub, number_vibrations, duration):
         i = 0
-        while True:
-            for v in range(0, duration):
+        mode = "NEW"
+
+        if mode == "SAFETY":
+            while True:
+                for v in range(0, duration):
+                    self.vibrate(vibrator_pub)
+                    time.sleep(0.01)
+                self.stop(vibrator_pub)
+                self.stop(vibrator_pub)
+                self.stop(vibrator_pub)
+
+                i += 1
+                if i >= number_vibrations:
+                    break
+                time.sleep(self.sleep/1000.0)
+
+            # make sure it stops
+            for v in range(0, 10):
+                self.stop(vibrator_pub)
+
+        if mode == "SIMPLE":
+            for i in range(0, number_vibrations):
                 self.vibrate(vibrator_pub)
-                time.sleep(0.01)
-            self.stop(vibrator_pub)
-            self.stop(vibrator_pub)
+                time.sleep(0.01*duration)
+                self.stop(vibrator_pub)
+                if i < number_vibrations - 1:
+                    time.sleep(self.sleep/1000.0)
             self.stop(vibrator_pub)
 
-            i += 1
-            if i >= number_vibrations:
-                break
-            time.sleep(self.sleep/1000.0)
-
-        # make sure it stops
-        for v in range(0, 10):
-            self.stop(vibrator_pub)
+        if mode == "NEW":
+            for i in range(0, number_vibrations):
+                msg = UInt8()
+                msg.data = duration
+                vibrator_pub.publish(msg)
+                time.sleep(0.01*duration)
+                if i < number_vibrations - 1:
+                    time.sleep(self.sleep/1000.0)

--- a/cabot/src/cabot/arduino_serial.cpp
+++ b/cabot/src/cabot/arduino_serial.cpp
@@ -259,8 +259,6 @@ void CaBotArduinoSerial::run_once()
         stop();
       }
     }
-    // } catch (const std::exception & error) {
-    // sometimes read error can happen even if it is okay.
   } catch (const std::exception & e) {
     delegate_->log(rclcpp::Logger::Level::Error, string_format("exception occurred during reading: %s", e.what()));
     stop();

--- a/cabot/src/cabot/cabot_serial.cpp
+++ b/cabot/src/cabot/cabot_serial.cpp
@@ -145,6 +145,9 @@ CaBotSerialNode::CaBotSerialNode(const rclcpp::NodeOptions & options)
 
 void CaBotSerialNode::vib_loop()
 {
+  if (client_ == nullptr) {
+    return;
+  }
   for (int i = 0; i < 4; i++) {
     // resend vibration command if the value of vibrator is not updated
     if (vibrations_[i].target > 0) {

--- a/cabot/src/cabot/cabot_serial.cpp
+++ b/cabot/src/cabot/cabot_serial.cpp
@@ -85,7 +85,8 @@ void CheckConnectionTask::run(diagnostic_updater::DiagnosticStatusWrapper & stat
 CaBotSerialNode::CaBotSerialNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("cabot_serial_node", options),
   updater_(this),
-  client_logger_(rclcpp::get_logger("arduino-serial"))
+  client_logger_(rclcpp::get_logger("arduino-serial")),
+  vibrations_({})
 {
   touch_raw_pub_ = this->create_publisher<std_msgs::msg::Int16>("touch_raw", rclcpp::QoS(10));
   touch_pub_ = this->create_publisher<std_msgs::msg::Int16>("touch", rclcpp::QoS(10));

--- a/cabot/src/cabot/cabot_serial.cpp
+++ b/cabot/src/cabot/cabot_serial.cpp
@@ -113,6 +113,7 @@ CaBotSerialNode::CaBotSerialNode(const rclcpp::NodeOptions & options)
   vib4_sub_ = this->create_subscription<std_msgs::msg::UInt8>(
     "vibrator4", 10, [this](const std_msgs::msg::UInt8::SharedPtr msg)
     {this->vib_callback(0x23, msg);});
+  vib_timer_ = this->create_wall_timer(0.01s, std::bind(&CaBotSerialNode::vib_loop, this));
 
   /* touch speed control
    * touch speed activw mode
@@ -142,10 +143,30 @@ CaBotSerialNode::CaBotSerialNode(const rclcpp::NodeOptions & options)
   updater_.add(*check_connection_task_);
 }
 
+void CaBotSerialNode::vib_loop()
+{
+  for (int i = 0; i < 4; i++) {
+    // resend vibration command if the value of vibrator is not updated
+    if (vibrations_[i].target > 0) {
+      if (vibrations_[i].target != vibrations_[i].current) {
+        vibrations_[i].count++;
+        std::vector<uint8_t> data;
+        data.push_back(vibrations_[i].target);
+        client_->send_command(0x20 + i, data);
+        RCLCPP_INFO(get_logger(), "resend vibrator %d value (%d != %d) [count=%d]",
+                    i, vibrations_[i].target, vibrations_[i].current, vibrations_[i].count);
+      } else {
+        vibrations_[i].target = vibrations_[i].current = vibrations_[i].count = 0;
+      }
+    }
+  }
+}
+
 void CaBotSerialNode::vib_callback(uint8_t cmd, const std_msgs::msg::UInt8::SharedPtr msg)
 {
   std::vector<uint8_t> data;
   data.push_back(msg->data);
+  vibrations_[cmd-0x20].target = msg->data;
   client_->send_command(cmd, data);
 }
 
@@ -412,7 +433,10 @@ void CaBotSerialNode::publish(uint8_t cmd, const std::vector<uint8_t> & data)
     temperature_pub_->publish(msg);
     temp_check_task_->tick();
   }
-  if (cmd == 0x20) {  // wifi
+  if (0x20 <= cmd && cmd <= 0x23) {  // vibrator feedback
+    vibrations_[cmd - 0x20].current = data[0];
+  }
+  if (cmd == 0x30) {  // wifi
     std_msgs::msg::String msg;
     msg.data = std::string(data.begin(), data.end());
     wifi_pub_->publish(msg);
@@ -449,13 +473,6 @@ int main(int argc, char ** argv)
       RCLCPP_DEBUG_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000.0, "run_once");
       try {
         client_->run_once();
-        /*}catch(const serial::SerialException& e){
-          error_msg_ = e.what();
-          RCLCPP_ERROR(this->get_logger(), error_msg_.c_str());
-          client_ = nullptr;
-          if (timer_){
-          timer_->cancel();
-          }*/
       } catch (const std::ios_base::failure & e) {  // IOError
         error_msg_ = e.what();
         RCLCPP_ERROR(node_->get_logger(), error_msg_);

--- a/cabot/src/cabot/cabot_serial.hpp
+++ b/cabot/src/cabot/cabot_serial.hpp
@@ -86,6 +86,12 @@ private:
   rclcpp::Logger logger_;
 };
 
+typedef struct Vibration {
+  uint8_t current;
+  uint8_t target;
+  int count;
+} Vibration;
+
 class CaBotSerialNode : public rclcpp::Node, public CaBotArduinoSerialDelegate
 {
 public:
@@ -126,9 +132,12 @@ private:
   rclcpp::Subscription<std_msgs::msg::UInt8>::SharedPtr vib2_sub_;
   rclcpp::Subscription<std_msgs::msg::UInt8>::SharedPtr vib3_sub_;
   rclcpp::Subscription<std_msgs::msg::UInt8>::SharedPtr vib4_sub_;
+  rclcpp::TimerBase::SharedPtr vib_timer_ = nullptr;
 
   bool is_alive_;
   static const size_t NUMBER_OF_BUTTONS = 5;
+  Vibration vibrations_[4];
+  void vib_loop();
   void vib_callback(const uint8_t cmd, const std_msgs::msg::UInt8::SharedPtr msg);
   std::shared_ptr<sensor_msgs::msg::Imu> process_imu_data(const std::vector<uint8_t> & data);
   void process_button_data(const std_msgs::msg::Int8::SharedPtr msg);


### PR DESCRIPTION
- Before: uint8 message to specify motor power of vibrators (0-255)
  - once set to 255, it keeps vibrating unless the value is set to 0
  - it requires to send start and stop signals
  - it may have some duration variance due to the time rag between PC and Arduino
  - sometimes, it keeps vibrating due to a serial message issue
- After : uint8 message to specify the duration of vibrators (0-255 x 10ms)
  - it will vibrate the motor for the specified duration

needs to update cabot-arduino as well
