### PR TITLE
Fix launch.sh to correctly launch the map server that has CABOT_SITE in its sub directories

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -267,7 +267,7 @@ if [ $error -eq 1 ]; then
    exit 1
 fi
 
-cabot_site_dir=$(find $scriptdir/cabot-navigation/cabot_sites -name $CABOT_SITE)
+cabot_site_dir=$(find $scriptdir/cabot-navigation/cabot_sites -name $CABOT_SITE | head -1)
 if [ -e $cabot_site_dir/server_data ]; then
     local_map_server=1
 fi


### PR DESCRIPTION
Fixed launch.sh script same as [cabot-navigation](https://github.com/CMU-cabot/cabot-navigation/blob/94dfff64a3d45878c9949f0e15b0ea06a8594690/launch.sh#L199).