### PR TITLE
add humble support (tentative)

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -310,10 +310,10 @@ if [ $simulation -eq 0 ]; then
 fi
 
 # prepare ROS host_ws
-if [[ -e /opt/ros/galactic/setup.bash ]]; then
+if [[ -e /opt/ros/$ROS_DISTRO/setup.bash ]]; then
     blue "build host_ws"
     cd $scriptdir/host_ws
-    source /opt/ros/galactic/setup.bash  # todo
+    source /opt/ros/$ROS_DISTRO/setup.bash  # todo
     if [ $verbose -eq 0 ]; then
 	colcon build > /dev/null
     else

--- a/launch.sh
+++ b/launch.sh
@@ -313,7 +313,7 @@ fi
 if [[ -e /opt/ros/$ROS_DISTRO/setup.bash ]]; then
     blue "build host_ws"
     cd $scriptdir/host_ws
-    source /opt/ros/$ROS_DISTRO/setup.bash  # todo
+    source /opt/ros/$ROS_DISTRO/setup.bash
     if [ $verbose -eq 0 ]; then
 	colcon build > /dev/null
     else

--- a/tools/install-host-ros2.sh
+++ b/tools/install-host-ros2.sh
@@ -22,9 +22,9 @@
 
 release_number=$(lsb_release -r | awk '{print $2}')
 if [[ "$release_number" == "20.04" ]]; then
-  local ROS_DISTRO="galactic"
+  ROS_DISTRO="galactic"
 elif [[ "$release_number" == "22.04" ]]; then
-  local ROS_DISTRO="humble"
+  ROS_DISTRO="humble"
 else
   cat /etc/lsb-release
   echo "This distribution release is not supported."

--- a/tools/install-host-ros2.sh
+++ b/tools/install-host-ros2.sh
@@ -23,7 +23,7 @@
 release_number=$(lsb_release -r | awk '{print $2}')
 if [[ "$release_number" == "20.04" ]]; then
   local ROS_DISTRO="galactic"
-elif [[ "$release_number" == "24.04" ]]; then
+elif [[ "$release_number" == "22.04" ]]; then
   local ROS_DISTRO="humble"
 else
   cat /etc/lsb-release

--- a/tools/install-host-ros2.sh
+++ b/tools/install-host-ros2.sh
@@ -20,6 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+release_number=$(lsb_release -r | awk '{print $2}')
+if [[ "$release_number" == "20.04" ]]; then
+  local ROS_DISTRO="galactic"
+elif [[ "$release_number" == "24.04" ]]; then
+  local ROS_DISTRO="humble"
+else
+  cat /etc/lsb-release
+  echo "This distribution release is not supported."
+  exit
+fi
+
 sudo apt install -y software-properties-common && \
 sudo add-apt-repository universe && \
 sudo apt update && sudo apt install -y curl  && \
@@ -27,7 +38,7 @@ sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
     -o /usr/share/keyrings/ros-archive-keyring.gpg && \
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
     | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null && \
-sudo apt update && sudo apt install -y ros-galactic-desktop
+sudo apt update && sudo apt install -y ros-$ROS_DISTRO-desktop
 
 # workaround
 # sudo dpkg -i --force-overwrite /var/cache/apt/archives/python3-catkin-pkg-modules_0.5.2-1_all.deb
@@ -37,5 +48,5 @@ sudo apt update && sudo apt install -y ros-galactic-desktop
 
 sudo apt install -y ros-dev-tools
 
-echo "source /opt/ros/galactic/setup.bash" >> ~/.bashrc && \
+echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc && \
 source ~/.bashrc


### PR DESCRIPTION
This change installs ROS 2 galactic or humble based on the release number.
After ROS 2 installation, the global variable `$ROS_DISTRO` is set when `source /opt/ros/$ROS_DISTRO` is commanded.
I have not yet done all the testing on humble, but this change does not interfere with the current galactic setting.