### PR TITLE
update launch.sh to save vcs log and diff for debugging

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -283,6 +283,9 @@ ln -snf $host_ros_log_dir $host_ros_log/latest
 blue "log dir is : $host_ros_log_dir"
 mkdir -p $host_ros_log_dir
 cp $scriptdir/.env $host_ros_log_dir/env-file
+# save vcs log and diff for debugging
+vcs log --nested --limit 1 > $host_ros_log_dir/vcs-log.txt &
+vcs diff --nested > $host_ros_log_dir/vcs-diff.txt &
 
 ## if network interface name for Cyclone DDS is not specified, set autoselect as true
 if [ ! -z $CYCLONEDDS_URI ]; then


### PR DESCRIPTION
This is a proposal for adding a small feature to save the outputs of `vcs log -n -l 1` and `vcs diff -n` to log directory to trace issues caused by local changes and/or inconsistencies between dependencies.