### PR TITLE
fix docker-compose-mapping.yaml by adding wifi_scan profile to prevent running multiple esp32 nodes

### DIFF
--- a/docker-compose-mapping.yaml
+++ b/docker-compose-mapping.yaml
@@ -106,6 +106,8 @@ services:
     extends:
       file: docker-compose-common.yaml
       service: wifi_scan
+    profiles:
+      - wifi_scan
     volumes:
       - ./docker/home:/home/developer
 


### PR DESCRIPTION
Fix a bug that mapping-launch.sh runs two esp32 serial nodes, one for IMU and another for Wi-Fi scanning, when -e (USE_ESP32) option is enabled.

This change only affects mapping using robot models equipped with a ESP32 as the micro-controller that communicates with sensors.