### PR TITLE
fix simulator issues when running on remote GPU servers by adding environmental variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ Please check those repositories for the details.
   CABOT_IMU_ACCEL_BIAS # set parameters to adjust IMU linear acceleration (default=[0.0,0.0,0.0])
   CABOT_IMU_GYRO_BIAS  # set parameters to adjust IMU angular velocity (default=[0.0,0.0,0.0])
   CYCLONEDDS_NETWORK_INTERFACE_NAME # to specify network interface name for Cyclone DDS
+  ROS_DOMAIN_ID        # to specify ROS domain ID; set this value when you use multiple ROS2 systems on the same network
+  __NV_PRIME_RENDER_OFFLOAD  # to use NVIDIA GPU for rendering; set to 1 if needed
+  __GLX_VENDOR_LIBRARY_NAME  # to use NVIDIA GPU for rendering; set to "nvidia" if needed
   ```
 - Options for debug/test
   ```

--- a/docker-compose-mapping-gazebo.yaml
+++ b/docker-compose-mapping-gazebo.yaml
@@ -39,6 +39,7 @@ services:
       - PLAYBAG_RATE_PC2_CONVERT
       - ROS_LOG_DIR
       - RMW_IMPLEMENTATION
+      - ROS_DOMAIN_ID
     volumes:
       - /dev:/dev
       - /sys/devices:/sys/devices

--- a/docker-compose-mapping.yaml
+++ b/docker-compose-mapping.yaml
@@ -39,6 +39,7 @@ services:
       - PLAYBAG_RATE_PC2_CONVERT
       - ROS_LOG_DIR
       - RMW_IMPLEMENTATION
+      - ROS_DOMAIN_ID
     volumes:
       - /dev:/dev
       - /sys/devices:/sys/devices


### PR DESCRIPTION
Fix issues when running multiple simulators on the same network by adding `ROS_DOMAIN_ID` to docker-compose files. 
Also, add descriptions about `ROS_DOMAIN_ID`, `__NV_PRIME_RENDER_OFFLOAD`, `__GLX_VENDOR_LIBRARY_NAME` to `readme.md`. 
`__NV_PRIME_RENDER_OFFLOAD` and `__GLX_VENDOR_LIBRARY_NAME` are needed to use GPU in the simulator in remote GPU server; these values are added to docker compose files in cabot-navigation repository.