### PR TITLE
update github workflows to increase build space

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -27,15 +27,10 @@ jobs:
   reusable_workflow_job:
     runs-on: ubuntu-20.04
     steps:
-    - name: Maximize build space
-      run:  |
-            sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-            sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-            sudo rm -rf /opt/ghc
-            echo "Available storage:"
-            df -h
-
     - uses: actions/checkout@v4
+
+    - name: Maximize Build Space
+      uses: ./.github/workflows/maximize-build-space
 
     - name: Install vcs
       run: pip3 install vcstool

--- a/.github/workflows/maximize-build-space/action.yaml
+++ b/.github/workflows/maximize-build-space/action.yaml
@@ -1,0 +1,27 @@
+name: Maximize Build Space
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run:  |
+        docker system prune -a --volumes -f
+        sudo apt purge -y \
+          ^aspnetcore* \
+          azure-cli* \
+          ^dotnet-* \
+          firefox* \
+          google-chrome-stable* \
+          google-cloud-* \
+          ^llvm* \
+          ^mongodb* \
+          ^mysql* \
+          php*
+        sudo apt-get autoremove -y
+        sudo apt-get autoclean -y
+        sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+        sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        echo "Available storage:"
+        df -h


### PR DESCRIPTION
update github workflows to fix image build failure https://github.com/CMU-cabot/cabot/actions/runs/10070284182/job/27890727825

maximize-build-space action increases the build space from 30 GB to 44 GB, which is sufficient to build people image.