### PR TITLE
fix maximize build space action not to remove temurin jdk

### DIFF
--- a/.github/workflows/maximize-build-space/action.yaml
+++ b/.github/workflows/maximize-build-space/action.yaml
@@ -37,7 +37,6 @@ runs:
           ruby* \
           sqlite3* \
           subversion \
-          temurin* \
           tmux* \
           vim* \
           yarn*


### PR DESCRIPTION
To fix github actions build failure

https://github.com/CMU-cabot/cabot/actions/runs/10232303117/job/28309282675

```
The following NEW packages will be installed:
  ca-certificates-java default-jre-headless libpcsclite1
  openjdk-11-jre-headless
0 upgraded, 4 newly installed, 530 to remove and 6 not upgraded.
Need to get 38.3 MB of archives.
After this operation, 6630 MB disk space will be freed.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 ca-certificates-java all 20190405ubuntu1.1 [12.4 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libpcsclite1 amd64 1.8.26-3 [22.0 kB]
Ign:4 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 openjdk-11-jre-headless amd64 11.0.23+9-1ubuntu1~20.04.2
Get:5 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 default-jre-headless amd64 2:1.11-72 [3192 B]
Ign:4 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 openjdk-11-jre-headless amd64 11.0.23+9-1ubuntu1~20.04.2
Ign:4 http://security.ubuntu.com/ubuntu focal-updates/main amd64 openjdk-11-jre-headless amd64 11.0.23+9-1ubuntu1~20.04.2
Err:4 mirror+file:/etc/apt/apt-mirrors.txt focal-updates/main amd64 openjdk-11-jre-headless amd64 11.0.23+9-1ubuntu1~20.04.2
  404  Not Found [IP: 52.252.163.49 80]
Fetched 37.6 kB in 1s (59.5 kB/s)
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/o/openjdk-lts/openjdk-11-jre-headless_11.0.23+9-1ubuntu1~20.04.2_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Installation of openjdk is caused by `apt purge temurin*` so removing `temurin*` from maximize-build-space action fixes the issue.