### PR TITLE
update launch.sh to log dmesg output without setting the argument

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -120,7 +120,7 @@ function help()
     echo "-c <name>   config name (default=) docker-compose(-<name>)(-production).yaml will use"
     echo "            if there is no nvidia-smi and config name is not set, automatically set to 'nuc'"
     echo "-3          equivalent to -c rs3"
-    echo "-M          log dmesg output"
+    echo "-W          disable dmesg logging"
     echo "-S          record screen cast"
     echo "-t          run test"
 }
@@ -138,7 +138,7 @@ config_name=
 local_map_server=0
 debug=0
 reset_all_realsence=0
-log_dmesg=0
+log_dmesg=1
 screen_recording=0
 run_test=0
 separate_log=0
@@ -162,7 +162,7 @@ if [ -n "$CABOT_LAUNCH_LOG_PREFIX" ]; then
     log_prefix=$CABOT_LAUNCH_LOG_PREFIX
 fi
 
-while getopts "hsdrp:n:vc:3DMStHR" arg; do
+while getopts "hsdrp:n:vc:3DWStHR" arg; do
     case $arg in
         s)
             simulation=1
@@ -195,8 +195,8 @@ while getopts "hsdrp:n:vc:3DMStHR" arg; do
         D)
             debug=1
             ;;
-        M)
-            log_dmesg=1
+        W)
+            log_dmesg=0
             ;;
         S)
             screen_recording=1

--- a/tools/cabot_config.sh
+++ b/tools/cabot_config.sh
@@ -34,3 +34,6 @@ $scriptdir/change_ble_config.sh
 
 # 2. increase UDP buffer to improve DDS performance
 $scriptdir/change_dds_settings.sh
+
+# 3. disable dmesg restrict for logging
+sudo sysctl -w kernel.dmesg_restrict=0


### PR DESCRIPTION
- Update launch.sh to log dmesg in the default state
    - Instead, add an argument to disable dmesg logging just in case
- Update cabot-config.sh to disable dmesg restrict