### PR TITLE
Fix mapping post processing with hesai lidar

### DIFF
--- a/docker-compose-mapping-post-process.yaml
+++ b/docker-compose-mapping-post-process.yaml
@@ -25,6 +25,7 @@ services:
       - BAG_FILENAME
       - QUIT_WHEN_ROSBAG_FINISH
       - PROCESS_GAZEBO_MAPPING
+      - LIDAR_MODEL # used for setting convert_points argument
     extends:
       file: docker-compose-mapping.yaml
       service: mapping

--- a/mapping-launch.sh
+++ b/mapping-launch.sh
@@ -162,6 +162,7 @@ if [[ -n $post_process ]]; then
     export BAG_FILENAME=${post_process_name%.*}
     export PLAYBAG_RATE_CARTOGRAPHER
     export PLAYBAG_RATE_PC2_CONVERT
+    export LIDAR_MODEL
     if [[ $gazebo -eq 1 ]]; then
         export PROCESS_GAZEBO_MAPPING=1
     fi


### PR DESCRIPTION
This pull request is opened for fixing a bug remained after pull request https://github.com/CMU-cabot/cabot/pull/181
In addition to this pull request, it is necessary to merge https://github.com/CMU-cabot/cabot-navigation/pull/71 to reflect the fixes.

In https://github.com/CMU-cabot/cabot/pull/181, `-L` option to specify LIDAR_MODEL was added to `mapping-launch.sh` script to enable mapping with lidar sensors other than VLP16 (XT16 or XT32).
It works with realtime mapping (e.g. `./mapping-launch.sh -e -L XT16 -c`) but it does not work with post processing (`./mapping-launch.sh -e -L XT16` then `./mapping-launch.sh -p PATH_TO_BAG_FILE`) because pointcloud data (`/velodyne_points`) is not recorded to the bag file.
This pull request fixes the issue.

It was confirmed that post processing worked with `-L XT16` option. (`./mapping-launch.sh -e -L XT16` then `./mapping-launch.sh -L XT16 -p PATH_TO_BAG_FILE`)
