### PR TITLE
add release action/script

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -10,11 +10,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+
+      - name: Install vcstool
+        run: |
+          pip install vcstool
+
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Export release dependency
-        run: ./setup-dependency.sh -r
+        run: |
+          # copy the checkout dir
+          cd ..
+          cp -r cabot cabot-temp
+          cd cabot-temp
+          # get all depedencies and freeze
+          ./setup-dependency.sh
+          ./setup-dependency.sh -r
+          # copy the release repos file
+          cp dependency-release.repos ../cabot
 
       - name: Create zip file
         run: |

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Create zip file
         run: |
+          rm -rf .git
           name=$(basename $(pwd))
           cd ..
           zip -r cabot-${{ github.ref_name }}.zip ${name}
@@ -43,4 +44,4 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: ./*.zip
+          artifacts: ../cabot-*.zip

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,30 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # Matches tags like v1.2.3
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Export release dependency
+        run: ./setup-dependency.sh -r
+
+      - name: Create zip file
+        run: |
+          name=$(basename $(pwd))
+          cd ..
+          zip -r cabot-${{ github.ref_name }}.zip ${name}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: ./*.zip

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -45,3 +45,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: ../cabot-*.zip
+
+      - name: Build docker image
+        run: |
+          curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.CABOT_BUILD_TOKEN}}" \
+          https://api.github.com/repos/CMU-cabot/cabot-build/dispatches \
+          -d '{"event_type": "build-release", "client_payload":{"ref_name": "${{ github.ref_name }}"}}'
+        env:
+          PAT: ${{ secrets.CABOT_BUILD_TOKEN }}

--- a/setup-dependency.sh
+++ b/setup-dependency.sh
@@ -32,12 +32,14 @@ function help {
     echo "-h                    show this help"
     echo "-c                    clean (rm -rf) dependency repositories"
     echo "-n <count>            max count for recursive check (default=2)"
+    echo "-r                    update depedency-release.repos"
 }
 
 clean=0
 count=3
+release=0
 
-while getopts "hcn:" arg; do
+while getopts "hcn:r" arg; do
     case $arg in
 	h)
 	    help
@@ -49,8 +51,19 @@ while getopts "hcn:" arg; do
 	n)
 	    count=$OPTARG
 	    ;;
+	r)
+	    release=1
+	    ;;
     esac
 done
+
+## export dependencies to dependency-release.repos
+if [[ $release -eq 1 ]]; then
+    mv .git .git-back  # work around to eliminate the current repository itself
+    vcs export -n --exact-with-tags > dependency-release.repos
+    mv .git-back .git  # restore the .git dir
+    exit
+fi
 
 
 if [[ $clean -eq 1 ]]; then
@@ -68,6 +81,16 @@ if [[ $clean -eq 1 ]]; then
     exit
 fi
 
+
+## for release
+if [[ -e dependency-release.repos ]]; then
+    echo "setup dependency from release"
+    vcs import < dependency-release.repos
+    exit
+fi
+
+
+## for dev
 declare -A visited
 
 for (( i=1; i<=count; i++ ))


### PR DESCRIPTION
- add `-r` option to freeze current dependencies with tag/commit-hash to dependency-release.repos
- the script will import dependency if dependency-release.repos exists
- add action to make a zip file with dependency-release.repos as artifact of a release