### PR TITLE
remove dependencies under ros2_ws

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -32,16 +32,3 @@ repositories:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
     version: main
-
-  # FIXME
-  docker/home/ros2_ws/src/rosbridge_suite:
-    type: git
-    url: https://github.com/CMU-cabot/rosbridge_suite
-    version: ros2-dev
-
-  # temporal fix until PR is merged and released
-  # https://github.com/ros/bond_core/pull/97
-  docker/home/ros2_ws/src/bond_core:
-    type: git
-    url: https://github.com/CMU-cabot/bond_core.git
-    version: galactic-fix


### PR DESCRIPTION
- depends on https://github.com/CMU-cabot/cabot-navigation/pull/88