### PR TITLE
fix mapping-launch script and docker compose file for mapping on simulator

### DIFF
--- a/docker-compose-mapping-gazebo.yaml
+++ b/docker-compose-mapping-gazebo.yaml
@@ -66,13 +66,38 @@ services:
     working_dir: /home/developer/mapping_ws
     command: /launch.sh mapping -C -X -s
 
+  # gazebo server
+  gazebo:
+    extends:
+      file: docker-compose-common.yaml
+      service: gazebo
+    profiles:
+      - start_gazebo
+    environment:
+      - CABOT_GAZEBO=1
+      - CABOT_USE_SIM_TIME=1
+
+  # gazebo client, rviz2, and teleop_twist_keyboard
   gui:
     extends:
       file: docker-compose-common.yaml
       service: gui
+    profiles:
+      - start_gazebo
     environment:
-      - ROS_LOG_DIR
-      - CABOT_SHOW_GAZEBO_CLIENT=0
-      - CABOT_SHOW_ROBOT_MONITOR=1
-      - CABOT_SHOW_ROS2_RVIZ=0
-      - CABOT_SHOW_ROS2_LOCAL_RVIZ=0
+      - CABOT_GAZEBO=1
+      - CABOT_USE_SIM_TIME=1
+      - CABOT_SHOW_GAZEBO_CLIENT=1
+      - CABOT_GUI_TELEOP_TWIST_TOPIC=/cabot/cmd_vel  # remap config for teleop_twist_keyboard node
+
+  # navigation container for running teleop_gamepad
+  navigation:
+    extends:
+      file: docker-compose-common.yaml
+      service: navigation
+    profiles:
+      - teleop_gamepad
+    environment:
+      - CABOT_GAZEBO=1
+      - CABOT_USE_SIM_TIME=1
+    command:  bash -c "source install/setup.bash && ros2 launch cabot_ui teleop_gamepad.launch.py cmd_vel:=/cabot/cmd_vel"

--- a/mapping-launch.sh
+++ b/mapping-launch.sh
@@ -205,51 +205,25 @@ blue "log dir is : $host_ros_log_dir"
 
 # set profile arg to run wifi_scan service only if USE_ESP32 is false
 if "$USE_ESP32"; then
-    PROFILE_ARG=""
+    PROFILE_ARGS=""
 else
-    PROFILE_ARG="--profile wifi_scan" # run wifi_scan service
+    PROFILE_ARGS="--profile wifi_scan" # run wifi_scan service
 fi
 
 dcfile=docker-compose-mapping.yaml
+# switch docker compose file if simulator option (-s or -S) is enabled
 if [[ $gazebo -eq 1 ]]; then
     dcfile=docker-compose-mapping-gazebo.yaml
+    # add docker compose profiles
     if [[ $boot -eq 1 ]]; then
-        if ls | grep -q cabot-navigation; then
-            cd cabot-navigation
-            if [[ -z $(docker ps -q -f "name=cabot-navigation-navigation") ]]; then
-                container="$container navigation"
-            else
-                echo "already boot cabot-navigation-navigation"
-            fi
-            if [[ -z $(docker ps -q -f "name=cabot-navigation-gui") ]]; then
-                container="$container gui"
-            else
-                echo "already boot cabot-navigation-gui"
-            fi
-            if [[ -z $(docker ps -q -f "name=cabot-navigation-gazebo") ]]; then
-                container="$container gazebo"
-            else
-                echo "already boot cabot-navigation-gazebo"
-            fi
-            if [[ -n $container ]]; then
-                docker compose up -d $container
-                sleep 6
-            fi
-            cd ..
-        else
-            echo "cannot find cabot-navigaton directory"
-        fi
+        PROFILE_ARGS="--profile start_gazebo $PROFILE_ARGS"
     fi
     if [[ $manipulate -eq 1 ]]; then
-        if [[ -z $(docker ps -q -f "name=cabot-navigation-navigation") ]]; then
-            echo "need to launch inside container of cabot-navigation for manipulate"
-        else
-            command="docker exec -itd cabot-navigation-navigation-1 bash -c 'source install/setup.bash && ros2 launch cabot_ui teleop_gamepad.launch.py'"
-            eval $command
-        fi
+        PROFILE_ARGS="--profile teleop_gamepad $PROFILE_ARGS"
     fi
 fi
-docker compose -f $dcfile $PROFILE_ARG up -d &
+
+docker compose -f $dcfile $PROFILE_ARGS up -d &
 snore 3
 docker compose -f $dcfile logs -f > $host_ros_log_dir/docker-compose.log  2>&1 &
 pid=$!
@@ -257,14 +231,7 @@ pid=$!
 trap ctrl_c INT QUIT TERM
 
 function ctrl_c() {
-    if ls | grep -q cabot-navigation; then
-        cd cabot-navigation
-        if [[ $boot -eq 1 ]] && [[ -n $container ]]; then
-            docker compose down $container
-        fi
-        cd ..
-    fi
-    docker compose -f $dcfile $PROFILE_ARG down
+    docker compose -f $dcfile $PROFILE_ARGS down
     exit 0
 }
 


### PR DESCRIPTION
Fixed mapping-launch.sh script and a related docker compose file to simplify data collection for mapping on simulator.
To enable this feature, it is necessary to merge this Pull Request https://github.com/CMU-cabot/cabot-navigation/pull/107.

Usage
1. prepare cabot_site data under cabot-navigation/cabot_sites directory
2. build workspace for gazebo
    ```
    $ cd cabot
    $ ./build-docker -w gazebo
    ```
3. run mapping-launch.sh script with an option to launch gazebo simulator
    ```
    $ ./mapping-launch.sh -S -m -o YOUR_OUTPUT_PREFIX
    ```
    `-m` option is not necessary when a joystick controller is not used.
4. control your robot with keyboard or joystick and collect data (pointcloud, imu, beacon etc.) for mapping