### PR TITLE
do not build debug image from cabot directory to prevent skipping build ros2_ws

### DIFF
--- a/bake-docker.sh
+++ b/bake-docker.sh
@@ -74,7 +74,7 @@ while getopts "hb:ilP:t:a" arg; do
         tags=${OPTARG}
         ;;
     a)
-        services="bag navigation localization debug map_server location_tools"
+        services="bag navigation localization map_server location_tools"
         ;;
     esac
 done

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,13 +81,6 @@ services:
     profiles:
       - build
 
-  debug:
-    extends:
-      file: cabot-navigation/docker-compose-debug.yaml
-      service: debug
-    profiles:
-      - build
-
   map_server:
     extends:
       file: cabot-navigation/docker-compose.yaml


### PR DESCRIPTION
I found [this change](https://github.com/CMU-cabot/cabot/commit/efe825148afc65119a7ea9225e35c568f51bf6bb) caused the issue that "build-workspace.sh" in cabot project skip building workspace in "ros2_ws" when the script is called for the first time.

Because we added "debug" service in "cabot/docker-compose.yaml", "build-workspace.sh" builds workspace in "cabot-navigation/docker/home/ros2_ws" and skip building workspace in "cabot/docker/home/ros2_ws".

Because "debug" service is used only by "cabot-navigation", I removed "debug" service from bake-docker.sh, docker-compose.yaml.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>