### PR TITLE
fix bug of bake-docker.sh, cannot copy images from local registry in cabot repository

### DIFF
--- a/bake-docker.sh
+++ b/bake-docker.sh
@@ -142,12 +142,12 @@ for service in ${services}; do
 done
 
 # bake
-base_com=
+com=
 if [[ -n $base_name ]]; then
-    base_com="docker buildx bake -f docker-compose.yaml $platform_option $tag_option $services"
+    com="docker buildx bake -f docker-compose.yaml $platform_option $tag_option $services"
     export BASE_IMAGE=$base_name
-    echo $base_com
-    eval $base_com
+    echo $com
+    eval $com
     if [[ $? -ne 0 ]]; then
         echo "failed to build image"
         exit 1


### PR DESCRIPTION
I fixed the bug that creating "cmucal/cabot-bag" image on local PC fails by following command.

```
./bake-docker.sh -i
```

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>