### PR TITLE
Improve release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env
 host_ws
 .tmp
+cabot-base
 cabot-common
 cabot-description
 cabot-drivers

--- a/dependency-override.repos
+++ b/dependency-override.repos
@@ -1,0 +1,26 @@
+#
+# this file is used by -o option of setup-dependency.repos (alternative option of deprecated -s option)
+# it is intended to use only for multi-repos dependency updates
+# developer can commit this file, but it may cause conflict during merge
+# 
+
+repositories:
+  cabot-common:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-common
+    version: daisukes/separate-common-and-base
+
+  cabot-drivers:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-drivers
+    version: improve-release
+
+  cabot-navigation:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-navigation
+    version: improve-release
+
+  cabot-people:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-people
+    version: improve-release

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -1,88 +1,92 @@
 repositories:
-  cabot-common:
+  cabot-base:
     type: git
-    url: https://github.com/CMU-cabot/cabot-common
-    version: 8239592941be937b7e708692c9ad4490f2478057
-  cabot-common/docker/docker_images:
+    url: git@github.com:cmu-cabot/cabot-base
+    version: 92b7e85ce73e252ee06891eb66c46ad7b7ba9353
+  cabot-base/docker/docker_images:
     type: git
     url: https://github.com/osrf/docker_images.git
     version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
-  cabot-common/docker/humble-custom/HesaiLidar_General_ros:
+  cabot-base/docker/humble-custom/HesaiLidar_General_ros:
     type: git
     url: https://github.com/cmu-cabot/HesaiLidar_General_ros
     version: a8f06572927e03d4fcebe14fbbd615db81bf8686
-  cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
+  cabot-base/docker/humble-custom/HesaiLidar_ROS_2.0:
     type: git
     url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
     version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
-  cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
+  cabot-base/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
     type: git
     url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
     version: 86d5da11437c60128b2061be9dfd89c65a4cb711
-  cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
+  cabot-base/docker/humble-custom/Lslidar_ROS2_driver:
     type: git
     url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
     version: 08d692c2adf62f29b991fe44313b17840e4bea8b
-  cabot-common/docker/humble-custom/bond_core:
+  cabot-base/docker/humble-custom/bond_core:
     type: git
     url: https://github.com/ros/bond_core.git
     version: 4.1.2
-  cabot-common/docker/humble-custom/gazebo_ros_pkgs:
+  cabot-base/docker/humble-custom/gazebo_ros_pkgs:
     type: git
     url: https://github.com/CMU-cabot/gazebo_ros_pkgs
     version: 115156c30013f370ae2087db6203b34449b8095b
-  cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
+  cabot-base/docker/humble-custom/livox_laser_simulation_ros2:
     type: git
     url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
     version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
-  cabot-common/docker/humble-custom/livox_ros2_driver:
+  cabot-base/docker/humble-custom/livox_ros2_driver:
     type: git
     url: https://github.com/DroneBase/livox_ros2_driver.git
     version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
-  cabot-common/docker/humble-custom/navigation2:
+  cabot-base/docker/humble-custom/navigation2:
     type: git
     url: https://github.com/ros-planning/navigation2
     version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
-  cabot-common/docker/humble-custom/people:
+  cabot-base/docker/humble-custom/people:
     type: git
     url: https://github.com/wg-perception/people.git
     version: 1.3.0
-  cabot-common/docker/humble-custom/perception_pcl:
+  cabot-base/docker/humble-custom/perception_pcl:
     type: git
     url: https://github.com/ros-perception/perception_pcl
     version: 2.6.2
-  cabot-common/docker/humble-custom/realsense_gazebo_plugin:
+  cabot-base/docker/humble-custom/realsense_gazebo_plugin:
     type: git
     url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
     version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
-  cabot-common/docker/humble-custom/ros2_persist_parameter_server:
+  cabot-base/docker/humble-custom/ros2_persist_parameter_server:
     type: git
     url: https://github.com/daisukes/ros2_persist_parameter_server
     version: 4d8186899cf7a10af2bea756d58b829628e26684
-  cabot-common/docker/humble-custom/rslidar_msg:
+  cabot-base/docker/humble-custom/rslidar_msg:
     type: git
     url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
     version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
-  cabot-common/docker/humble-custom/rslidar_sdk:
+  cabot-base/docker/humble-custom/rslidar_sdk:
     type: git
     url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
     version: v1.5.16
-  cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
+  cabot-base/docker/humble-custom/rslidar_sdk/src/rs_driver:
     type: git
     url: https://github.com/RoboSense-LiDAR/rs_driver.git
     version: v1.5.16
-  cabot-common/docker/humble-custom/velodyne:
+  cabot-base/docker/humble-custom/velodyne:
     type: git
     url: https://github.com/ros-drivers/velodyne.git
     version: 2.5.1
-  cabot-common/docker/humble-custom/velodyne_simulator:
+  cabot-base/docker/humble-custom/velodyne_simulator:
     type: git
     url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
     version: foxy-2020-10-14-all-repos
-  cabot-common/docker/opengl:
+  cabot-base/docker/opengl:
     type: git
     url: https://gitlab.com/nvidia/container-images/opengl.git
     version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+  cabot-common:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-common
+    version: 1d784dce364ad6e7e4b9f1da54baa4c51a8a8254
   cabot-description:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
@@ -90,91 +94,11 @@ repositories:
   cabot-drivers:
     type: git
     url: https://github.com/CMU-cabot/cabot-drivers
-    version: 0582d68c2d4bc9e7d0d2e8f263b4cc3bd6bf5e9e
+    version: 096fd56e2bd841f484028a2b76e5f1c8aa837143
   cabot-drivers/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
-    version: 8239592941be937b7e708692c9ad4490f2478057
-  cabot-drivers/cabot-common/docker/docker_images:
-    type: git
-    url: https://github.com/osrf/docker_images.git
-    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
-  cabot-drivers/cabot-common/docker/humble-custom/HesaiLidar_General_ros:
-    type: git
-    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
-    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
-  cabot-drivers/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
-    type: git
-    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
-    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
-  cabot-drivers/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
-    type: git
-    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
-    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
-  cabot-drivers/cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
-    type: git
-    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
-    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
-  cabot-drivers/cabot-common/docker/humble-custom/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
-    version: 4.1.2
-  cabot-drivers/cabot-common/docker/humble-custom/gazebo_ros_pkgs:
-    type: git
-    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
-    version: 115156c30013f370ae2087db6203b34449b8095b
-  cabot-drivers/cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
-    type: git
-    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
-    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
-  cabot-drivers/cabot-common/docker/humble-custom/livox_ros2_driver:
-    type: git
-    url: https://github.com/DroneBase/livox_ros2_driver.git
-    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
-  cabot-drivers/cabot-common/docker/humble-custom/navigation2:
-    type: git
-    url: https://github.com/ros-planning/navigation2
-    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
-  cabot-drivers/cabot-common/docker/humble-custom/people:
-    type: git
-    url: https://github.com/wg-perception/people.git
-    version: 1.3.0
-  cabot-drivers/cabot-common/docker/humble-custom/perception_pcl:
-    type: git
-    url: https://github.com/ros-perception/perception_pcl
-    version: 2.6.2
-  cabot-drivers/cabot-common/docker/humble-custom/realsense_gazebo_plugin:
-    type: git
-    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
-    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
-  cabot-drivers/cabot-common/docker/humble-custom/ros2_persist_parameter_server:
-    type: git
-    url: https://github.com/daisukes/ros2_persist_parameter_server
-    version: 4d8186899cf7a10af2bea756d58b829628e26684
-  cabot-drivers/cabot-common/docker/humble-custom/rslidar_msg:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
-    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
-  cabot-drivers/cabot-common/docker/humble-custom/rslidar_sdk:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
-    version: v1.5.16
-  cabot-drivers/cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rs_driver.git
-    version: v1.5.16
-  cabot-drivers/cabot-common/docker/humble-custom/velodyne:
-    type: git
-    url: https://github.com/ros-drivers/velodyne.git
-    version: 2.5.1
-  cabot-drivers/cabot-common/docker/humble-custom/velodyne_simulator:
-    type: git
-    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
-    version: foxy-2020-10-14-all-repos
-  cabot-drivers/cabot-common/docker/opengl:
-    type: git
-    url: https://gitlab.com/nvidia/container-images/opengl.git
-    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+    version: 1d784dce364ad6e7e4b9f1da54baa4c51a8a8254
   cabot-drivers/cabot-description:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
@@ -186,91 +110,11 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 2248a4813f7afcf42e0c363a141b942dff109250
+    version: 7d24aae6426036546a9dabbd1642865dd347b59e
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
-    version: 8239592941be937b7e708692c9ad4490f2478057
-  cabot-navigation/cabot-common/docker/docker_images:
-    type: git
-    url: https://github.com/osrf/docker_images.git
-    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
-  cabot-navigation/cabot-common/docker/humble-custom/HesaiLidar_General_ros:
-    type: git
-    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
-    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
-  cabot-navigation/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
-    type: git
-    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
-    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
-  cabot-navigation/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
-    type: git
-    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
-    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
-  cabot-navigation/cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
-    type: git
-    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
-    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
-  cabot-navigation/cabot-common/docker/humble-custom/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
-    version: 4.1.2
-  cabot-navigation/cabot-common/docker/humble-custom/gazebo_ros_pkgs:
-    type: git
-    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
-    version: 115156c30013f370ae2087db6203b34449b8095b
-  cabot-navigation/cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
-    type: git
-    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
-    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
-  cabot-navigation/cabot-common/docker/humble-custom/livox_ros2_driver:
-    type: git
-    url: https://github.com/DroneBase/livox_ros2_driver.git
-    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
-  cabot-navigation/cabot-common/docker/humble-custom/navigation2:
-    type: git
-    url: https://github.com/ros-planning/navigation2
-    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
-  cabot-navigation/cabot-common/docker/humble-custom/people:
-    type: git
-    url: https://github.com/wg-perception/people.git
-    version: 1.3.0
-  cabot-navigation/cabot-common/docker/humble-custom/perception_pcl:
-    type: git
-    url: https://github.com/ros-perception/perception_pcl
-    version: 2.6.2
-  cabot-navigation/cabot-common/docker/humble-custom/realsense_gazebo_plugin:
-    type: git
-    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
-    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
-  cabot-navigation/cabot-common/docker/humble-custom/ros2_persist_parameter_server:
-    type: git
-    url: https://github.com/daisukes/ros2_persist_parameter_server
-    version: 4d8186899cf7a10af2bea756d58b829628e26684
-  cabot-navigation/cabot-common/docker/humble-custom/rslidar_msg:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
-    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
-  cabot-navigation/cabot-common/docker/humble-custom/rslidar_sdk:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
-    version: v1.5.16
-  cabot-navigation/cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rs_driver.git
-    version: v1.5.16
-  cabot-navigation/cabot-common/docker/humble-custom/velodyne:
-    type: git
-    url: https://github.com/ros-drivers/velodyne.git
-    version: 2.5.1
-  cabot-navigation/cabot-common/docker/humble-custom/velodyne_simulator:
-    type: git
-    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
-    version: foxy-2020-10-14-all-repos
-  cabot-navigation/cabot-common/docker/opengl:
-    type: git
-    url: https://gitlab.com/nvidia/container-images/opengl.git
-    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+    version: 1d784dce364ad6e7e4b9f1da54baa4c51a8a8254
   cabot-navigation/cabot-description:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
@@ -310,91 +154,11 @@ repositories:
   cabot-people:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
-    version: da541f3bebeced279e2703829b2c30be50597937
+    version: 817ec0a9e65a98870e192e194a08d1bbbadedda2
   cabot-people/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
-    version: 8239592941be937b7e708692c9ad4490f2478057
-  cabot-people/cabot-common/docker/docker_images:
-    type: git
-    url: https://github.com/osrf/docker_images.git
-    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
-  cabot-people/cabot-common/docker/humble-custom/HesaiLidar_General_ros:
-    type: git
-    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
-    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
-  cabot-people/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
-    type: git
-    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
-    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
-  cabot-people/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
-    type: git
-    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
-    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
-  cabot-people/cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
-    type: git
-    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
-    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
-  cabot-people/cabot-common/docker/humble-custom/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
-    version: 4.1.2
-  cabot-people/cabot-common/docker/humble-custom/gazebo_ros_pkgs:
-    type: git
-    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
-    version: 115156c30013f370ae2087db6203b34449b8095b
-  cabot-people/cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
-    type: git
-    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
-    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
-  cabot-people/cabot-common/docker/humble-custom/livox_ros2_driver:
-    type: git
-    url: https://github.com/DroneBase/livox_ros2_driver.git
-    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
-  cabot-people/cabot-common/docker/humble-custom/navigation2:
-    type: git
-    url: https://github.com/ros-planning/navigation2
-    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
-  cabot-people/cabot-common/docker/humble-custom/people:
-    type: git
-    url: https://github.com/wg-perception/people.git
-    version: 1.3.0
-  cabot-people/cabot-common/docker/humble-custom/perception_pcl:
-    type: git
-    url: https://github.com/ros-perception/perception_pcl
-    version: 2.6.2
-  cabot-people/cabot-common/docker/humble-custom/realsense_gazebo_plugin:
-    type: git
-    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
-    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
-  cabot-people/cabot-common/docker/humble-custom/ros2_persist_parameter_server:
-    type: git
-    url: https://github.com/daisukes/ros2_persist_parameter_server
-    version: 4d8186899cf7a10af2bea756d58b829628e26684
-  cabot-people/cabot-common/docker/humble-custom/rslidar_msg:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
-    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
-  cabot-people/cabot-common/docker/humble-custom/rslidar_sdk:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
-    version: v1.5.16
-  cabot-people/cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
-    type: git
-    url: https://github.com/RoboSense-LiDAR/rs_driver.git
-    version: v1.5.16
-  cabot-people/cabot-common/docker/humble-custom/velodyne:
-    type: git
-    url: https://github.com/ros-drivers/velodyne.git
-    version: 2.5.1
-  cabot-people/cabot-common/docker/humble-custom/velodyne_simulator:
-    type: git
-    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
-    version: foxy-2020-10-14-all-repos
-  cabot-people/cabot-common/docker/opengl:
-    type: git
-    url: https://gitlab.com/nvidia/container-images/opengl.git
-    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+    version: 1d784dce364ad6e7e4b9f1da54baa4c51a8a8254
   cabot-people/docker/jetson-humble-custom/people:
     type: git
     url: https://github.com/wg-perception/people.git

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -94,7 +94,7 @@ repositories:
   cabot-drivers:
     type: git
     url: https://github.com/CMU-cabot/cabot-drivers
-    version: 096fd56e2bd841f484028a2b76e5f1c8aa837143
+    version: bbfda2cf16b357061bc58729cc50785352588077
   cabot-drivers/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -110,7 +110,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 7d24aae6426036546a9dabbd1642865dd347b59e
+    version: c622fd7673d836f9287da1305cc1fd6833376b3f
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -154,7 +154,91 @@ repositories:
   cabot-people:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
-    version: 817ec0a9e65a98870e192e194a08d1bbbadedda2
+    version: 2fff40639540fb00ba71e1cb590686ae97a2487b
+  cabot-people/cabot-base:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-base
+    version: 92b7e85ce73e252ee06891eb66c46ad7b7ba9353
+  cabot-people/cabot-base/docker/docker_images:
+    type: git
+    url: https://github.com/osrf/docker_images.git
+    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
+  cabot-people/cabot-base/docker/humble-custom/HesaiLidar_General_ros:
+    type: git
+    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
+    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
+  cabot-people/cabot-base/docker/humble-custom/HesaiLidar_ROS_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
+    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
+  cabot-people/cabot-base/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
+    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
+  cabot-people/cabot-base/docker/humble-custom/Lslidar_ROS2_driver:
+    type: git
+    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
+    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
+  cabot-people/cabot-base/docker/humble-custom/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: 4.1.2
+  cabot-people/cabot-base/docker/humble-custom/gazebo_ros_pkgs:
+    type: git
+    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
+    version: 115156c30013f370ae2087db6203b34449b8095b
+  cabot-people/cabot-base/docker/humble-custom/livox_laser_simulation_ros2:
+    type: git
+    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
+    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
+  cabot-people/cabot-base/docker/humble-custom/livox_ros2_driver:
+    type: git
+    url: https://github.com/DroneBase/livox_ros2_driver.git
+    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
+  cabot-people/cabot-base/docker/humble-custom/navigation2:
+    type: git
+    url: https://github.com/ros-planning/navigation2
+    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
+  cabot-people/cabot-base/docker/humble-custom/people:
+    type: git
+    url: https://github.com/wg-perception/people.git
+    version: 1.3.0
+  cabot-people/cabot-base/docker/humble-custom/perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl
+    version: 2.6.2
+  cabot-people/cabot-base/docker/humble-custom/realsense_gazebo_plugin:
+    type: git
+    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
+    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
+  cabot-people/cabot-base/docker/humble-custom/ros2_persist_parameter_server:
+    type: git
+    url: https://github.com/daisukes/ros2_persist_parameter_server
+    version: 4d8186899cf7a10af2bea756d58b829628e26684
+  cabot-people/cabot-base/docker/humble-custom/rslidar_msg:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
+  cabot-people/cabot-base/docker/humble-custom/rslidar_sdk:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+    version: v1.5.16
+  cabot-people/cabot-base/docker/humble-custom/rslidar_sdk/src/rs_driver:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rs_driver.git
+    version: v1.5.16
+  cabot-people/cabot-base/docker/humble-custom/velodyne:
+    type: git
+    url: https://github.com/ros-drivers/velodyne.git
+    version: 2.5.1
+  cabot-people/cabot-base/docker/humble-custom/velodyne_simulator:
+    type: git
+    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
+    version: foxy-2020-10-14-all-repos
+  cabot-people/cabot-base/docker/opengl:
+    type: git
+    url: https://gitlab.com/nvidia/container-images/opengl.git
+    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
   cabot-people/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -1,0 +1,409 @@
+repositories:
+  cabot-common:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-common
+    version: 8239592941be937b7e708692c9ad4490f2478057
+  cabot-common/docker/docker_images:
+    type: git
+    url: https://github.com/osrf/docker_images.git
+    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
+  cabot-common/docker/humble-custom/HesaiLidar_General_ros:
+    type: git
+    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
+    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
+  cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
+    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
+  cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
+    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
+  cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
+    type: git
+    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
+    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
+  cabot-common/docker/humble-custom/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: 4.1.2
+  cabot-common/docker/humble-custom/gazebo_ros_pkgs:
+    type: git
+    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
+    version: 115156c30013f370ae2087db6203b34449b8095b
+  cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
+    type: git
+    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
+    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
+  cabot-common/docker/humble-custom/livox_ros2_driver:
+    type: git
+    url: https://github.com/DroneBase/livox_ros2_driver.git
+    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
+  cabot-common/docker/humble-custom/navigation2:
+    type: git
+    url: https://github.com/ros-planning/navigation2
+    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
+  cabot-common/docker/humble-custom/people:
+    type: git
+    url: https://github.com/wg-perception/people.git
+    version: 1.3.0
+  cabot-common/docker/humble-custom/perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl
+    version: 2.6.2
+  cabot-common/docker/humble-custom/realsense_gazebo_plugin:
+    type: git
+    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
+    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
+  cabot-common/docker/humble-custom/ros2_persist_parameter_server:
+    type: git
+    url: https://github.com/daisukes/ros2_persist_parameter_server
+    version: 4d8186899cf7a10af2bea756d58b829628e26684
+  cabot-common/docker/humble-custom/rslidar_msg:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
+  cabot-common/docker/humble-custom/rslidar_sdk:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+    version: v1.5.16
+  cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rs_driver.git
+    version: v1.5.16
+  cabot-common/docker/humble-custom/velodyne:
+    type: git
+    url: https://github.com/ros-drivers/velodyne.git
+    version: 2.5.1
+  cabot-common/docker/humble-custom/velodyne_simulator:
+    type: git
+    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
+    version: foxy-2020-10-14-all-repos
+  cabot-common/docker/opengl:
+    type: git
+    url: https://gitlab.com/nvidia/container-images/opengl.git
+    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+  cabot-description:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-description
+    version: 5374b9b5d3a252e8cd174b4b83baca891a671a22
+  cabot-drivers:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-drivers
+    version: 0582d68c2d4bc9e7d0d2e8f263b4cc3bd6bf5e9e
+  cabot-drivers/cabot-common:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-common
+    version: 8239592941be937b7e708692c9ad4490f2478057
+  cabot-drivers/cabot-common/docker/docker_images:
+    type: git
+    url: https://github.com/osrf/docker_images.git
+    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
+  cabot-drivers/cabot-common/docker/humble-custom/HesaiLidar_General_ros:
+    type: git
+    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
+    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
+  cabot-drivers/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
+    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
+  cabot-drivers/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
+    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
+  cabot-drivers/cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
+    type: git
+    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
+    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
+  cabot-drivers/cabot-common/docker/humble-custom/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: 4.1.2
+  cabot-drivers/cabot-common/docker/humble-custom/gazebo_ros_pkgs:
+    type: git
+    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
+    version: 115156c30013f370ae2087db6203b34449b8095b
+  cabot-drivers/cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
+    type: git
+    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
+    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
+  cabot-drivers/cabot-common/docker/humble-custom/livox_ros2_driver:
+    type: git
+    url: https://github.com/DroneBase/livox_ros2_driver.git
+    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
+  cabot-drivers/cabot-common/docker/humble-custom/navigation2:
+    type: git
+    url: https://github.com/ros-planning/navigation2
+    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
+  cabot-drivers/cabot-common/docker/humble-custom/people:
+    type: git
+    url: https://github.com/wg-perception/people.git
+    version: 1.3.0
+  cabot-drivers/cabot-common/docker/humble-custom/perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl
+    version: 2.6.2
+  cabot-drivers/cabot-common/docker/humble-custom/realsense_gazebo_plugin:
+    type: git
+    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
+    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
+  cabot-drivers/cabot-common/docker/humble-custom/ros2_persist_parameter_server:
+    type: git
+    url: https://github.com/daisukes/ros2_persist_parameter_server
+    version: 4d8186899cf7a10af2bea756d58b829628e26684
+  cabot-drivers/cabot-common/docker/humble-custom/rslidar_msg:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
+  cabot-drivers/cabot-common/docker/humble-custom/rslidar_sdk:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+    version: v1.5.16
+  cabot-drivers/cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rs_driver.git
+    version: v1.5.16
+  cabot-drivers/cabot-common/docker/humble-custom/velodyne:
+    type: git
+    url: https://github.com/ros-drivers/velodyne.git
+    version: 2.5.1
+  cabot-drivers/cabot-common/docker/humble-custom/velodyne_simulator:
+    type: git
+    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
+    version: foxy-2020-10-14-all-repos
+  cabot-drivers/cabot-common/docker/opengl:
+    type: git
+    url: https://gitlab.com/nvidia/container-images/opengl.git
+    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+  cabot-drivers/cabot-description:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-description
+    version: 5374b9b5d3a252e8cd174b4b83baca891a671a22
+  cabot-drivers/docker/driver/ros_odrive:
+    type: git
+    url: https://github.com/CMU-cabot/ros_odrive.git
+    version: 0a3cc6e8e94388eeebb7b80841df6f9e70ceaffd
+  cabot-navigation:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-navigation
+    version: 2248a4813f7afcf42e0c363a141b942dff109250
+  cabot-navigation/cabot-common:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-common
+    version: 8239592941be937b7e708692c9ad4490f2478057
+  cabot-navigation/cabot-common/docker/docker_images:
+    type: git
+    url: https://github.com/osrf/docker_images.git
+    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
+  cabot-navigation/cabot-common/docker/humble-custom/HesaiLidar_General_ros:
+    type: git
+    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
+    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
+  cabot-navigation/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
+    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
+  cabot-navigation/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
+    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
+  cabot-navigation/cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
+    type: git
+    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
+    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
+  cabot-navigation/cabot-common/docker/humble-custom/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: 4.1.2
+  cabot-navigation/cabot-common/docker/humble-custom/gazebo_ros_pkgs:
+    type: git
+    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
+    version: 115156c30013f370ae2087db6203b34449b8095b
+  cabot-navigation/cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
+    type: git
+    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
+    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
+  cabot-navigation/cabot-common/docker/humble-custom/livox_ros2_driver:
+    type: git
+    url: https://github.com/DroneBase/livox_ros2_driver.git
+    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
+  cabot-navigation/cabot-common/docker/humble-custom/navigation2:
+    type: git
+    url: https://github.com/ros-planning/navigation2
+    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
+  cabot-navigation/cabot-common/docker/humble-custom/people:
+    type: git
+    url: https://github.com/wg-perception/people.git
+    version: 1.3.0
+  cabot-navigation/cabot-common/docker/humble-custom/perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl
+    version: 2.6.2
+  cabot-navigation/cabot-common/docker/humble-custom/realsense_gazebo_plugin:
+    type: git
+    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
+    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
+  cabot-navigation/cabot-common/docker/humble-custom/ros2_persist_parameter_server:
+    type: git
+    url: https://github.com/daisukes/ros2_persist_parameter_server
+    version: 4d8186899cf7a10af2bea756d58b829628e26684
+  cabot-navigation/cabot-common/docker/humble-custom/rslidar_msg:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
+  cabot-navigation/cabot-common/docker/humble-custom/rslidar_sdk:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+    version: v1.5.16
+  cabot-navigation/cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rs_driver.git
+    version: v1.5.16
+  cabot-navigation/cabot-common/docker/humble-custom/velodyne:
+    type: git
+    url: https://github.com/ros-drivers/velodyne.git
+    version: 2.5.1
+  cabot-navigation/cabot-common/docker/humble-custom/velodyne_simulator:
+    type: git
+    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
+    version: foxy-2020-10-14-all-repos
+  cabot-navigation/cabot-common/docker/opengl:
+    type: git
+    url: https://gitlab.com/nvidia/container-images/opengl.git
+    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+  cabot-navigation/cabot-description:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-description
+    version: 5374b9b5d3a252e8cd174b4b83baca891a671a22
+  cabot-navigation/docker/localization/RTKLIB:
+    type: git
+    url: https://github.com/tomojitakasu/RTKLIB.git
+    version: v2.4.3-b34
+  cabot-navigation/docker/localization/bluespace_ai_xsens_ros_mti_driver:
+    type: git
+    url: https://github.com/pshved/bluespace_ai_xsens_ros_mti_driver.git
+    version: 706ea91f4a91f7fa7a9b87ff6c9f7eb79407fdf4
+  cabot-navigation/docker/localization/cartographer:
+    type: git
+    url: https://github.com/CMU-cabot/cartographer.git
+    version: ed9c582787051180150d3bf751bedb97d18e6718
+  cabot-navigation/docker/localization/cartographer_ros:
+    type: git
+    url: https://github.com/CMU-cabot/cartographer_ros.git
+    version: aabd1d6e708cf04e15ff4f2a4dbe18b948de8ae9
+  cabot-navigation/docker/localization/ntrip_client:
+    type: git
+    url: https://github.com/cmu-cabot/ntrip_client.git
+    version: 666e0e8dd50f8690812542aac45bfb06095a4668
+  cabot-navigation/docker/localization/ublox:
+    type: git
+    url: https://github.com/CMU-cabot/ublox.git
+    version: 18b425a3f9a581a71d22567541dcbb06fc4750e0
+  cabot-navigation/docker/ros2/rosbridge_suite:
+    type: git
+    url: https://github.com/CMU-cabot/rosbridge_suite
+    version: 1b698a76aee904adb370e7b7d77b8355325f3747
+  cabot-navigation/docker/ros2/tf2_web_republisher:
+    type: git
+    url: https://github.com/CMU-cabot/tf2_web_republisher
+    version: 2398595fa46569737bb58c93f4451c08460c41d8
+  cabot-people:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-people
+    version: da541f3bebeced279e2703829b2c30be50597937
+  cabot-people/cabot-common:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-common
+    version: 8239592941be937b7e708692c9ad4490f2478057
+  cabot-people/cabot-common/docker/docker_images:
+    type: git
+    url: https://github.com/osrf/docker_images.git
+    version: 7f78d698d677a9800356b171ab99c4d76f0c18bd
+  cabot-people/cabot-common/docker/humble-custom/HesaiLidar_General_ros:
+    type: git
+    url: https://github.com/cmu-cabot/HesaiLidar_General_ros
+    version: a8f06572927e03d4fcebe14fbbd615db81bf8686
+  cabot-people/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
+    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
+  cabot-people/cabot-common/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
+    type: git
+    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
+    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
+  cabot-people/cabot-common/docker/humble-custom/Lslidar_ROS2_driver:
+    type: git
+    url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
+    version: 08d692c2adf62f29b991fe44313b17840e4bea8b
+  cabot-people/cabot-common/docker/humble-custom/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: 4.1.2
+  cabot-people/cabot-common/docker/humble-custom/gazebo_ros_pkgs:
+    type: git
+    url: https://github.com/CMU-cabot/gazebo_ros_pkgs
+    version: 115156c30013f370ae2087db6203b34449b8095b
+  cabot-people/cabot-common/docker/humble-custom/livox_laser_simulation_ros2:
+    type: git
+    url: https://github.com/CMU-cabot/livox_laser_simulation_ros2.git
+    version: 89c5a2bebd33aebdea318e5768fc6acb17cca0f0
+  cabot-people/cabot-common/docker/humble-custom/livox_ros2_driver:
+    type: git
+    url: https://github.com/DroneBase/livox_ros2_driver.git
+    version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
+  cabot-people/cabot-common/docker/humble-custom/navigation2:
+    type: git
+    url: https://github.com/ros-planning/navigation2
+    version: e7f37b95e0cafc2192c0c841a65dfba9f5632157
+  cabot-people/cabot-common/docker/humble-custom/people:
+    type: git
+    url: https://github.com/wg-perception/people.git
+    version: 1.3.0
+  cabot-people/cabot-common/docker/humble-custom/perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl
+    version: 2.6.2
+  cabot-people/cabot-common/docker/humble-custom/realsense_gazebo_plugin:
+    type: git
+    url: https://github.com/cmu-cabot/realsense_gazebo_plugin.git
+    version: 2d330e7b556e51fa45a3b83620c335c6baa6ee1c
+  cabot-people/cabot-common/docker/humble-custom/ros2_persist_parameter_server:
+    type: git
+    url: https://github.com/daisukes/ros2_persist_parameter_server
+    version: 4d8186899cf7a10af2bea756d58b829628e26684
+  cabot-people/cabot-common/docker/humble-custom/rslidar_msg:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+    version: fe8a95cb242bd294cc3d5e3422f2093fb49a56ee
+  cabot-people/cabot-common/docker/humble-custom/rslidar_sdk:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+    version: v1.5.16
+  cabot-people/cabot-common/docker/humble-custom/rslidar_sdk/src/rs_driver:
+    type: git
+    url: https://github.com/RoboSense-LiDAR/rs_driver.git
+    version: v1.5.16
+  cabot-people/cabot-common/docker/humble-custom/velodyne:
+    type: git
+    url: https://github.com/ros-drivers/velodyne.git
+    version: 2.5.1
+  cabot-people/cabot-common/docker/humble-custom/velodyne_simulator:
+    type: git
+    url: https://github.com/ToyotaResearchInstitute/velodyne_simulator
+    version: foxy-2020-10-14-all-repos
+  cabot-people/cabot-common/docker/opengl:
+    type: git
+    url: https://gitlab.com/nvidia/container-images/opengl.git
+    version: 6b92c40aaa1e30f7880e421ea46a40da63524518
+  cabot-people/docker/jetson-humble-custom/people:
+    type: git
+    url: https://github.com/wg-perception/people.git
+    version: 1.3.0
+  cabot-people/docker/realsense/realsense_ros:
+    type: git
+    url: https://github.com/IntelRealSense/realsense-ros.git
+    version: 4.55.1
+  host_ws/src/tf_bag:
+    type: git
+    url: https://github.com/IFL-CAMP/tf_bag
+    version: 72d0c9abc5a795a45008e9ed32f2c14d0213b255

--- a/dependency.repos
+++ b/dependency.repos
@@ -8,6 +8,11 @@ repositories:
     url: https://github.com/IFL-CAMP/tf_bag
     version: ROS2/devel
 
+  cabot-base:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-base
+    version: main
+
   cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -337,7 +337,7 @@ services:
       - ./cabot-navigation/docker/localization/ublox/ublox_msgs:/home/developer/bag_ws/src/ublox_msgs
       - ./cabot-navigation/docker/localization/ublox/ublox_serialization:/home/developer/bag_ws/src/ublox_serialization
       - ./cabot-navigation/docker/localization/cartographer_ros/cartographer_ros_msgs:/home/developer/bag_ws/src/cartographer_ros_msgs
-      - ./cabot-common/docker/humble-custom/velodyne/velodyne_msgs:/home/developer/bag_ws/src/velodyne_msgs
+      - ./cabot-base/docker/humble-custom/velodyne/velodyne_msgs:/home/developer/bag_ws/src/velodyne_msgs
       - ./host_ws/src/tf_bag:/home/developer/bag_ws/src/tf_bag
       - ${CABOT_BAG_MOUNT:-./doc}:/ros2_topics
     profiles:

--- a/docker/bag/Dockerfile
+++ b/docker/bag/Dockerfile
@@ -103,7 +103,7 @@ COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-description/cabot_desc
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/docker/localization/ublox/ublox_msgs /home/developer/bag_ws/src/ublox_msgs
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/docker/localization/ublox/ublox_serialization /home/developer/bag_ws/src/ublox_serialization
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/docker/localization/cartographer_ros/cartographer_ros_msgs /home/developer/bag_ws/src/cartographer_ros_msgs
-COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-common/docker/humble-custom/velodyne/velodyne_msgs /home/developer/bag_ws/src/velodyne_msgs
+COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-base/docker/humble-custom/velodyne/velodyne_msgs /home/developer/bag_ws/src/velodyne_msgs
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/pedestrian_plugin_msgs /home/developer/bag_ws/src/pedestrian_plugin_msgs
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./host_ws/src/tf_bag /home/developer/bag_ws/src/tf_bag
 

--- a/host_ws/src/people_msgs
+++ b/host_ws/src/people_msgs
@@ -1,1 +1,1 @@
-../../cabot-common/docker/humble-custom/people/people_msgs
+../../cabot-base/docker/humble-custom/people/people_msgs

--- a/setup-dependency.sh
+++ b/setup-dependency.sh
@@ -28,7 +28,7 @@ function blue {
 
 
 function help {
-    echo "Usage: $0 <option>"    
+    echo "Usage: $0 <option>"
     echo ""
     echo "-h                    show this help"
     echo "-c                    clean (rm -rf) dependency repositories"
@@ -96,14 +96,16 @@ fi
 if [[ $clean -eq 1 ]]; then
     pwd=$(pwd)
     find * -name ".git" | while read -r line; do
-        pushd $line/../
-        if git diff --quiet && ! git ls-files --others --exclude-standard | grep -q .; then
-            echo "rm -rf $pwd/$(dirname $line)"
-            sudo rm -rf $pwd/$(dirname $line)
-        else
-            blue "There are unstaged/untracked changes in $line"
+        if [[ -d $line/../ ]]; then
+            pushd $line/../
+            if git diff --quiet && ! git ls-files --others --exclude-standard | grep -q .; then
+                echo "rm -rf $pwd/$(dirname $line)"
+                rm -rf $pwd/$(dirname $line)
+            else
+                blue "There are unstaged/untracked changes in $line"
+            fi
+            popd
         fi
-        popd
     done
     exit
 fi

--- a/setup-dependency.sh
+++ b/setup-dependency.sh
@@ -65,22 +65,22 @@ while getopts "hcdn:or" arg; do
         c)
             clean=1
             ;;
-	d)
-	    development=1
-	    ;;
+        d)
+            development=1
+            ;;
         n)
             count=$OPTARG
             ;;
-	o)
-	    override=1
-	    ;;
+        o)
+            override=1
+            ;;
         r)
             release=1
             ;;
-	*)
-	    help
-	    exit
-	    ;;
+        *)
+            help
+            exit
+            ;;
     esac
 done
 
@@ -134,12 +134,13 @@ do
 
             temp_file=$(mktemp)
             echo "Temporary file created: $temp_file"
-	    if [[ $override -eq 1 ]]; then
-		cat $line > $temp_file
-		cat ${line/.repos/-override.repos} | sed s/repositories:// >> $temp_file
-  	    else
-		cat $line > $temp_file
-	    fi
+            cat $line > $temp_file
+            if [[ $override -eq 1 ]]; then
+                override_file=${line/.repos/-override.repos}
+                if [[ -e $override_file ]]; then
+                    cat $override_file | sed s/repositories:// >> $temp_file
+                fi
+            fi
             blue "$(dirname $line)/ vcs import < $temp_file"
             pushd $(dirname $line)
             vcs import < $temp_file

--- a/setup-dependency.sh
+++ b/setup-dependency.sh
@@ -26,39 +26,49 @@ function blue {
     echo -en "\033[0m"  ## reset color
 }
 
+
 function help {
-    echo "Usage: $0 <option>"
+    echo "Usage: $0 <option>"    
     echo ""
     echo "-h                    show this help"
     echo "-c                    clean (rm -rf) dependency repositories"
-    echo "-n <count>            max count for recursive check (default=2)"
+    echo "-n <count>            max count for recursive check (default=3)"
     echo "-r                    update depedency-release.repos"
-    echo "-s <sed cmd>          apply sed to dependency.repos file with the command"
+    echo "-d                    use dependency.repos and dependency-dev.repos not dependency-release.repos"
+    echo "-o                    use dependency-override.repos"
+    echo ""
+    echo "# dependency.repos          # refer sub repos by mainly branches, cyclic"
+    echo "# dependency-override.repos # override dependency.repos for dev branches (you can commit)"
+    echo "# dependency-release.repose # freezed one, including all sub-sub repos, non-cyclic"
+    echo ""
+    echo "example"
+    echo "$0                  # most common"
+    echo "$0 -d               # for development"
+    echo ""
+    echo "edit dependency-override.repos  # override reuqired repos branches"
+    echo "$0 -d -o            # use dependency.repos overwritten by dependency-override.repos"
 }
 
 clean=0
 count=3
 release=0
-sed_cmd=
 
-while getopts "hcn:rs:" arg; do
+while getopts "hcn:r" arg; do
     case $arg in
-	h)
-	    help
-	    exit
-	    ;;
-	c)
-	    clean=1
-	    ;;
-	n)
-	    count=$OPTARG
-	    ;;
-	r)
-	    release=1
-	    ;;
-	s)
-	    sed_cmd=$OPTARG
-	    ;;
+        h)
+            help
+            exit
+            ;;
+        c)
+            clean=1
+            ;;
+        n)
+            count=$OPTARG
+            ;;
+        r)
+            release=1
+            ;;
+
     esac
 done
 
@@ -72,16 +82,16 @@ fi
 
 
 if [[ $clean -eq 1 ]]; then
-	pwd=$(pwd)
+    pwd=$(pwd)
     find * -name ".git" | while read -r line; do
-		pushd $line/../
-		if git diff --quiet && ! git ls-files --others --exclude-standard | grep -q .; then
-			echo "rm -rf $pwd/$(dirname $line)"
-			#rm -rf $pwd/$(dirname $line)
-		else
-			blue "There are unstaged/untracked changes in $line"
-		fi
-		popd
+        pushd $line/../
+        if git diff --quiet && ! git ls-files --others --exclude-standard | grep -q .; then
+            echo "rm -rf $pwd/$(dirname $line)"
+            sudo rm -rf $pwd/$(dirname $line)
+        else
+            blue "There are unstaged/untracked changes in $line"
+        fi
+        popd
     done
     exit
 fi
@@ -104,28 +114,20 @@ do
 
     flag=0
     for line in ${files[@]}; do
-	if [[ -z ${visited[$line]} ]]; then
-	    flag=1
-	    visited[$line]=1
-	    
-	    temp_file=$(mktemp)
-	    echo "Temporary file created: $temp_file"
-	    cat $line > $temp_file
-	    if [[ ! -z $sed_cmd ]]; then
-		com="sed -i '$sed_cmd' $temp_file"
-		echo $com
-		eval $com
-		if [[ $? -ne 0 ]]; then
-		    exit 1
-		fi
-	    fi
-	    blue "$(dirname $line)/ vcs import < $temp_file"
-	    pushd $(dirname $line)
-	    vcs import < $temp_file
-	    popd
-	fi
+        if [[ -z ${visited[$line]} ]]; then
+            flag=1
+            visited[$line]=1
+
+            temp_file=$(mktemp)
+            echo "Temporary file created: $temp_file"
+            cat $line > $temp_file
+            blue "$(dirname $line)/ vcs import < $temp_file"
+            pushd $(dirname $line)
+            vcs import < $temp_file
+            popd
+        fi
     done
     if [[ $flag -eq 0 ]]; then
-	break
+        break
     fi
 done

--- a/setup-dependency.sh
+++ b/setup-dependency.sh
@@ -32,25 +32,31 @@ function help {
     echo ""
     echo "-h                    show this help"
     echo "-c                    clean (rm -rf) dependency repositories"
-    echo "-d                    use dependency.repos and dependency-dev.repos not dependency-release.repos"
     echo "-n <count>            max count for recursive check (default=3)"
     echo "-r                    update depedency-release.repos"
+    echo "-d                    use dependency.repos and dependency-dev.repos not dependency-release.repos"
+    echo "-o                    use dependency-override.repos"
+    echo "-s                    **DEPRECATED** use -o option instead"
     echo ""
     echo "# dependency.repos          # refer sub repos by mainly branches, cyclic"
+    echo "# dependency-override.repos # override dependency.repos for dev branches (you can commit)"
     echo "# dependency-release.repose # freezed one, including all sub-sub repos, non-cyclic"
     echo ""
     echo "example"
     echo "$0                  # most common"
     echo "$0 -d               # for development"
+    echo ""
+    echo "edit dependency-override.repos  # override reuqired repos branches"
+    echo "$0 -d -o            # use dependency.repos overwritten by dependency-override.repos"
 }
 
 clean=0
 count=3
 release=0
 development=0
+override=0
 
-
-while getopts "hcdn:r" arg; do
+while getopts "hcdn:or" arg; do
     case $arg in
         h)
             help
@@ -59,16 +65,22 @@ while getopts "hcdn:r" arg; do
         c)
             clean=1
             ;;
-        d)
-            development=1
-            ;;
+	d)
+	    development=1
+	    ;;
         n)
             count=$OPTARG
             ;;
+	o)
+	    override=1
+	    ;;
         r)
             release=1
             ;;
-
+	*)
+	    help
+	    exit
+	    ;;
     esac
 done
 
@@ -120,8 +132,13 @@ do
 
             temp_file=$(mktemp)
             echo "Temporary file created: $temp_file"
-            cat $line > $temp_file
-	    "$(dirname $line)/ vcs import < $temp_file"
+	    if [[ $override -eq 1 ]]; then
+		cat $line > $temp_file
+		cat ${line/.repos/-override.repos} | sed s/repositories:// >> $temp_file
+  	    else
+		cat $line > $temp_file
+	    fi
+            blue "$(dirname $line)/ vcs import < $temp_file"
             pushd $(dirname $line)
             vcs import < $temp_file
             popd

--- a/setup-dependency.sh
+++ b/setup-dependency.sh
@@ -32,28 +32,25 @@ function help {
     echo ""
     echo "-h                    show this help"
     echo "-c                    clean (rm -rf) dependency repositories"
+    echo "-d                    use dependency.repos and dependency-dev.repos not dependency-release.repos"
     echo "-n <count>            max count for recursive check (default=3)"
     echo "-r                    update depedency-release.repos"
-    echo "-d                    use dependency.repos and dependency-dev.repos not dependency-release.repos"
-    echo "-o                    use dependency-override.repos"
     echo ""
     echo "# dependency.repos          # refer sub repos by mainly branches, cyclic"
-    echo "# dependency-override.repos # override dependency.repos for dev branches (you can commit)"
     echo "# dependency-release.repose # freezed one, including all sub-sub repos, non-cyclic"
     echo ""
     echo "example"
     echo "$0                  # most common"
     echo "$0 -d               # for development"
-    echo ""
-    echo "edit dependency-override.repos  # override reuqired repos branches"
-    echo "$0 -d -o            # use dependency.repos overwritten by dependency-override.repos"
 }
 
 clean=0
 count=3
 release=0
+development=0
 
-while getopts "hcn:r" arg; do
+
+while getopts "hcdn:r" arg; do
     case $arg in
         h)
             help
@@ -61,6 +58,9 @@ while getopts "hcn:r" arg; do
             ;;
         c)
             clean=1
+            ;;
+        d)
+            development=1
             ;;
         n)
             count=$OPTARG
@@ -98,7 +98,7 @@ fi
 
 
 ## for release
-if [[ -e dependency-release.repos ]]; then
+if [[ -e dependency-release.repos ]] && [[ $development -eq 0 ]]; then
     echo "setup dependency from release"
     vcs import < dependency-release.repos
     exit
@@ -110,7 +110,7 @@ declare -A visited
 
 for (( i=1; i<=count; i++ ))
 do
-    files=$(find . -name "dependency.repos")
+    files=$(find . -name "dependency.repos" | awk '{print length, $0}' | sort -n | cut -d' ' -f2-)
 
     flag=0
     for line in ${files[@]}; do
@@ -121,7 +121,7 @@ do
             temp_file=$(mktemp)
             echo "Temporary file created: $temp_file"
             cat $line > $temp_file
-            blue "$(dirname $line)/ vcs import < $temp_file"
+	    "$(dirname $line)/ vcs import < $temp_file"
             pushd $(dirname $line)
             vcs import < $temp_file
             popd


### PR DESCRIPTION
- separate cabot-base from cabot-common
  - https://github.com/CMU-cabot/cabot-base
  - cabot-base is dedicated to cabot-base image build
  - cabot-common contains common script/code
  - this can avoid cloning unnecessary dependencies to the repo that only uses cabot-common part
- update setup-dependency.sh behavior
  - default use dependency-release.repos, to track commit/tag level dependencies at cabot repo
  - dependency.repos is for development (branch)
  - dependency-override.repose can be used with the `-o` option, this is a replacement of the `-s` option
    - `-s` sed replace is buggy
    - `./setup-dependency.sh -d -o` should make a development environment with multi-repos branch dependency update
- https://github.com/CMU-cabot/cabot-navigation/pull/133
- https://github.com/CMU-cabot/cabot-people/pull/25
- https://github.com/CMU-cabot/cabot-drivers/pull/48