### PR TITLE
clean up ros_entrypoint.sh for supporting the command with double quotes in docker compose files

### DIFF
--- a/docker/bag/ros_entrypoint.sh
+++ b/docker/bag/ros_entrypoint.sh
@@ -51,6 +51,4 @@ else
     source /opt/custom_ws/install/setup.bash
 fi
 
-WORKDIR=$(pwd)
-
-exec gosu developer bash -c "cd $WORKDIR && exec $*"
+exec gosu developer "$@"


### PR DESCRIPTION
This pull request fixed issue that command in docker compose file does not support special characters.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>