### PR TITLE
fix set-floor_and_estimate.sh to work correctly when localization image is shared by two or more containers

### DIFF
--- a/cabot_debug/set-floor_and_estimate.sh
+++ b/cabot_debug/set-floor_and_estimate.sh
@@ -34,7 +34,7 @@ done
 shift $((OPTIND-1))
 
 
-container_id=`docker ps | grep localization | cut -d " " -f 1`
+container_id=`docker ps --format "{{.ID}} {{.Names}}" | grep localization | cut -d " " -f 1`
 docker exec $container_id bash -c 'source install/setup.bash; ros2 service call /set_current_floor mf_localization_msgs/srv/MFSetInt "{data: '$floor'}"'
 sleep 3
 ros2 topic pub -1 /initialpose geometry_msgs/PoseWithCovarianceStamped '{ header: {frame_id: "map_global"}, pose: { pose: {position: {x: '$CABOT_INITX', y: '$CABOT_INITY'}}}}'


### PR DESCRIPTION
This pull request fixes a bug that set-floor_and_estimate.sh script does not work when localization image is used by two or more containers (e.g. cabot-localization and cabot-rtk_gnss containers).