### PR TITLE
Improve termination for better logging

### DIFF
--- a/cabot_debug/launch/play_bag.launch.py
+++ b/cabot_debug/launch/play_bag.launch.py
@@ -174,6 +174,7 @@ def generate_launch_description():
                 executable='map_server',
                 name='map_server',
                 parameters=[{'yaml_filename': map}],
+                output=output,
                 condition=LaunchConfigurationNotEquals('map', "")
             ),
 
@@ -181,7 +182,7 @@ def generate_launch_description():
                 package='nav2_lifecycle_manager',
                 executable='lifecycle_manager',
                 name='lifecycle_manager_navigation',
-                output='log',
+                output=output,
                 parameters=[{'autostart': True},
                             {'bond_timeout': 60.0},
                             {'node_names': ['map_server'

--- a/cabot_debug/launch/record_system_stat.launch.py
+++ b/cabot_debug/launch/record_system_stat.launch.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025  Carnegie Mellon University
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from launch.logging import launch_config
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.actions import SetEnvironmentVariable
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnShutdown
+from cabot_common.launch import AppendLogDirPrefix
+
+
+def generate_launch_description():
+    output = {}
+    return LaunchDescription([
+        DeclareLaunchArgument('sigterm_timeout', default_value='30'),
+        # save all log file in the directory where the launch.log file is saved
+        SetEnvironmentVariable('ROS_LOG_DIR', launch_config.log_dir),
+        RegisterEventHandler(OnShutdown(on_shutdown=[AppendLogDirPrefix("record_system_stat")])),
+        Node(
+            package='cabot_debug',
+            executable='command_logger.py',
+            name='top_node',
+            output=output,
+            parameters=[{'topic': '/top', 'command': 'top -bcd 1'}]
+        ),
+        # The following nodes were commented out in the XML:
+        # Node(
+        #     package='cabot_debug',
+        #     executable='command_logger.py',
+        #     name='lscpu_node',
+        #     output=output,
+        #     parameters=[{'topic': '/lscpu', 'command': 'lscpu', 'frequency': 1.0}]
+        # ),
+        # Node(
+        #     package='cabot_debug',
+        #     executable='command_logger.py',
+        #     name='sensors_node',
+        #     output=output,
+        #     parameters=[{'topic': '/sensors', 'command': 'sensors', 'frequency': 1.0}]
+        # ),
+        Node(
+            package='cabot_debug',
+            executable='command_logger.py',
+            name='nvidia_smi_node',
+            output=output,
+            parameters=[{'topic': '/nvidia_smi_dmon', 'command': 'nvidia-smi dmon'}]
+        ),
+        Node(
+            package='cabot_debug',
+            executable='command_logger.py',
+            name='tegrastats_node',
+            output=output,
+            parameters=[{'topic': '/tegrastats', 'command': 'tegrastats'}]
+        )
+    ])

--- a/cabot_debug/launch/record_system_stat.launch.py
+++ b/cabot_debug/launch/record_system_stat.launch.py
@@ -29,9 +29,9 @@ from cabot_common.launch import AppendLogDirPrefix
 
 
 def generate_launch_description():
-    output = {}
+    output = {'stderr': {'log'}}
     return LaunchDescription([
-        DeclareLaunchArgument('sigterm_timeout', default_value='30'),
+        DeclareLaunchArgument('sigterm_timeout', default_value='15'),
         # save all log file in the directory where the launch.log file is saved
         SetEnvironmentVariable('ROS_LOG_DIR', launch_config.log_dir),
         RegisterEventHandler(OnShutdown(on_shutdown=[AppendLogDirPrefix("record_system_stat")])),

--- a/dependency-override.repos
+++ b/dependency-override.repos
@@ -5,22 +5,27 @@
 # 
 
 repositories:
-  cabot-dashboard:
-    type: git
-    url: https://github.com/CMU-cabot/cabot-dashboard
-    version: dev
-
-#  cabot-drivers:
+#  cabot-dashboard:
 #    type: git
-#    url: https://github.com/CMU-cabot/cabot-drivers
+#    url: https://github.com/CMU-cabot/cabot-dashboard
 #    version: dev
+
+  cabot-drivers:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-drivers
+    version: daisukes/improve-termination
 
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: dev
+    version: dev-improve-termination
 
 #  cabot-base:
 #    type: git
 #    url: https://github.com/CMU-cabot/cabot-base
 #    version: hesai-ros2-nav2-update
+
+  cabot-people:
+    type: git
+    url: https://github.com/CMU-cabot/cabot-people
+    version: daisukes/improve-termination

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -46,7 +46,7 @@ repositories:
   cabot-base/docker/humble-custom/navigation2:
     type: git
     url: https://github.com/cmu-cabot/navigation2
-    version: e94db84592135f4e7e9029e4a11a6c842d53b0a6
+    version: 0e9331080dffb61b2941d976634461e3667ffc76
   cabot-base/docker/humble-custom/people:
     type: git
     url: https://github.com/wg-perception/people.git
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 3e7ff4d32617508c7606ff2bb15ddd9b27d4ef37
+    version: 5cbb1448b9f997ce00c66cab736aa47de59a3dda
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -222,7 +222,7 @@ repositories:
   cabot-people/cabot-base/docker/humble-custom/navigation2:
     type: git
     url: https://github.com/cmu-cabot/navigation2
-    version: e94db84592135f4e7e9029e4a11a6c842d53b0a6
+    version: 0e9331080dffb61b2941d976634461e3667ffc76
   cabot-people/cabot-base/docker/humble-custom/people:
     type: git
     url: https://github.com/wg-perception/people.git

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: e96d617d6e38763b16a3e794840ce9cdeec4ca6c
+    version: 76ef96807aaa16c403ca4b1daaf317bc8fcee6dc
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -94,7 +94,7 @@ repositories:
   cabot-dashboard:
     type: git
     url: https://github.com/CMU-cabot/cabot-dashboard
-    version: 6d788a1026a10cde5bab8c067556934ed243c485
+    version: 49c4f5a55035d973489f7113ce68928bd9eabfed
   cabot-description:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
@@ -102,7 +102,7 @@ repositories:
   cabot-drivers:
     type: git
     url: https://github.com/CMU-cabot/cabot-drivers
-    version: 40f9fd7e9f8987eaaf60abb8ebcc20b0cd1e80ea
+    version: d4c1aa9a2b7d7b215436846b3d32d6cab4098dd0
   cabot-drivers/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 3254dae8b254feb23b909f1f60703398ea5f5d35
+    version: e96d617d6e38763b16a3e794840ce9cdeec4ca6c
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -178,7 +178,7 @@ repositories:
   cabot-people:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
-    version: a94bb16683e42ce1f1bd16a4d39c627aaa136300
+    version: ad4d64b1a3525d7e36800e56fa4f8d25554356d0
   cabot-people/cabot-base:
     type: git
     url: https://github.com/CMU-cabot/cabot-base

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -94,7 +94,7 @@ repositories:
   cabot-dashboard:
     type: git
     url: https://github.com/CMU-cabot/cabot-dashboard
-    version: 49c4f5a55035d973489f7113ce68928bd9eabfed
+    version: 0349dd82ab04e613541f63268c8dea8f14d354e9
   cabot-description:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
@@ -102,7 +102,7 @@ repositories:
   cabot-drivers:
     type: git
     url: https://github.com/CMU-cabot/cabot-drivers
-    version: d4c1aa9a2b7d7b215436846b3d32d6cab4098dd0
+    version: a78e995c7b79f01174b88974f2ff6c49e27b3dcd
   cabot-drivers/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -94,7 +94,7 @@ repositories:
   cabot-dashboard:
     type: git
     url: https://github.com/CMU-cabot/cabot-dashboard
-    version: 2006bff537ad62bedc44245065fcf0ad80c5a453
+    version: 6d788a1026a10cde5bab8c067556934ed243c485
   cabot-description:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
@@ -102,7 +102,7 @@ repositories:
   cabot-drivers:
     type: git
     url: https://github.com/CMU-cabot/cabot-drivers
-    version: 774ad6f2e146209020bc39f8e4456eacd7982e8a
+    version: 40f9fd7e9f8987eaaf60abb8ebcc20b0cd1e80ea
   cabot-drivers/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 6b4d1cbac4f1b063fa97595860922d1c459da143
+    version: 3254dae8b254feb23b909f1f60703398ea5f5d35
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -178,7 +178,7 @@ repositories:
   cabot-people:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
-    version: 09a45a5dbd104ec422ea10a7b8e09d38ba9e8034
+    version: a94bb16683e42ce1f1bd16a4d39c627aaa136300
   cabot-people/cabot-base:
     type: git
     url: https://github.com/CMU-cabot/cabot-base

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -94,7 +94,7 @@ repositories:
   cabot-dashboard:
     type: git
     url: https://github.com/CMU-cabot/cabot-dashboard
-    version: d140c18dee9b2590d12b83954224fb380811a191
+    version: 2006bff537ad62bedc44245065fcf0ad80c5a453
   cabot-description:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 5cbb1448b9f997ce00c66cab736aa47de59a3dda
+    version: 6b4d1cbac4f1b063fa97595860922d1c459da143
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -45,7 +45,7 @@ repositories:
     version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
   cabot-base/docker/humble-custom/navigation2:
     type: git
-    url: https://github.com/CMU-cabot/navigation2.git
+    url: https://github.com/cmu-cabot/navigation2
     version: e94db84592135f4e7e9029e4a11a6c842d53b0a6
   cabot-base/docker/humble-custom/people:
     type: git
@@ -102,7 +102,7 @@ repositories:
   cabot-drivers:
     type: git
     url: https://github.com/CMU-cabot/cabot-drivers
-    version: 23cf4265b3fb1767bbd3df5bac99363a21b7e5d4
+    version: 774ad6f2e146209020bc39f8e4456eacd7982e8a
   cabot-drivers/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: e15103e9aeb22021feb312d9e0c3cb0084754262
+    version: 3e7ff4d32617508c7606ff2bb15ddd9b27d4ef37
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -178,7 +178,7 @@ repositories:
   cabot-people:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
-    version: 012e0750fc3b9f827af71596a27c75d6bb1e3549
+    version: 09a45a5dbd104ec422ea10a7b8e09d38ba9e8034
   cabot-people/cabot-base:
     type: git
     url: https://github.com/CMU-cabot/cabot-base
@@ -194,11 +194,11 @@ repositories:
   cabot-people/cabot-base/docker/humble-custom/HesaiLidar_ROS_2.0:
     type: git
     url: https://github.com/CMU-cabot/HesaiLidar_ROS_2.0
-    version: 21c3d2dc54ad583d5898fb43ed4dcc6cd84d5ae4
+    version: c362b8d5d2c7e56419f58fbf36606329f77b72f4
   cabot-people/cabot-base/docker/humble-custom/HesaiLidar_ROS_2.0/src/driver/HesaiLidar_SDK_2.0:
     type: git
-    url: https://github.com/CMU-cabot/HesaiLidar_SDK_2.0
-    version: 86d5da11437c60128b2061be9dfd89c65a4cb711
+    url: https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0
+    version: 76cb882dcdaa54e48feca1bbdfba8caae91c785a
   cabot-people/cabot-base/docker/humble-custom/Lslidar_ROS2_driver:
     type: git
     url: https://github.com/Lslidar/Lslidar_ROS2_driver.git
@@ -221,8 +221,8 @@ repositories:
     version: 72cb73eec26fd982b408cf7318faf8c36bb0b587
   cabot-people/cabot-base/docker/humble-custom/navigation2:
     type: git
-    url: https://github.com/ros-planning/navigation2
-    version: 7ee3d2f65fcf42e18c41e0801199a33aa0b4c76e
+    url: https://github.com/cmu-cabot/navigation2
+    version: e94db84592135f4e7e9029e4a11a6c842d53b0a6
   cabot-people/cabot-base/docker/humble-custom/people:
     type: git
     url: https://github.com/wg-perception/people.git

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -331,6 +331,7 @@ services:
       - NET_ADMIN
     network_mode: host
     stop_signal: SIGINT
+    stop_grace_period: 30s
     command: /launch.sh record
 
   bag-dev:
@@ -359,13 +360,9 @@ services:
       - ./cabot-base/docker/humble-custom/velodyne/velodyne_msgs:/home/developer/bag_ws/src/velodyne_msgs
       - ./host_ws/src/tf_bag:/home/developer/bag_ws/src/tf_bag
       - ${CABOT_BAG_MOUNT:-./doc}:/ros2_topics
-    profiles:
-      - dev
 
   bag-prod:
     extends:
       service: bag-base
     volumes:
       - ${CABOT_BAG_MOUNT:-./doc}:/ros2_topics
-    profiles:
-      - prod

--- a/docker/bag/Dockerfile
+++ b/docker/bag/Dockerfile
@@ -95,6 +95,7 @@ COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-drivers/docker/driver/
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-drivers/docker/driver/ros_odrive/odrive_node /home/developer/bag_ws/src/ros_odrive/odrive_node
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-drivers/power_controller/power_controller_msgs /home/developer/bag_ws/src/power_controller/power_controller_msgs
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/cabot_gazebo /home/developer/bag_ws/src/cabot_gazebo
+COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/docker/ros2/tf2_web_republisher /home/developer/bag_ws/src/tf2_web_republisher
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/script /home/developer/bag_ws/script
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/mf_localization_msgs /home/developer/bag_ws/src/mf_localization_msgs
 COPY --chown=$USERNAME:$USERNAME --from=cabot_src ./cabot-navigation/mf_localization_rviz /home/developer/bag_ws/src/mf_localization_rviz
@@ -132,10 +133,13 @@ RUN apt update && \
     bc \
     gosu \
     ros-$ROS_DISTRO-dwb-msgs \
-    ros-$ROS_DISTRO-rosbridge-msgs \
     ros-$ROS_DISTRO-nav2-lifecycle-manager \
     ros-$ROS_DISTRO-nav2-map-server \
     ros-$ROS_DISTRO-nav2-msgs \
+    ros-$ROS_DISTRO-nmea-msgs \
+    ros-$ROS_DISTRO-realsense2-camera-msgs \
+    ros-$ROS_DISTRO-rosbridge-msgs \
+    ros-$ROS_DISTRO-rtcm-msgs \
     nlohmann-json3-dev \
     && \
     rm -rf /var/lib/apt/lists/*

--- a/launch.sh
+++ b/launch.sh
@@ -133,7 +133,7 @@ function help()
     echo "-d          development"
     echo "-W          disable dmesg logging"
     echo "-S          record screen cast"
-    echo "-t          run test"
+    echo "-t          run test (deprecated)"
 }
 
 
@@ -149,7 +149,6 @@ local_map_server=0
 reset_all_realsence=0
 log_dmesg=1
 screen_recording=0
-run_test=0
 separate_log=0
 profile=prod
 
@@ -215,7 +214,9 @@ while getopts "hsdrp:n:vc:3DWStHR" arg; do
             screen_recording=1
             ;;
         t)
-            run_test=1
+            red "test option is deprecated, please run test under cabot-navigation"
+            help
+            exit
             ;;
         H)
             export CABOT_HEADLESS=1
@@ -467,14 +468,6 @@ done
 blue "All launched: $( echo "$(date +%s.%N) - $start" | bc -l )"
 
 env_option=
-if [[ $run_test -eq 1 ]]; then
-    blue "Running test"
-    docker compose exec navigation /home/developer/ros2_ws/script/run_test.sh
-    pids+=($!)
-    runtest_pid=$!
-    snore 3
-fi
-
 
 while [ 1 -eq 1 ];
 do

--- a/launch.sh
+++ b/launch.sh
@@ -332,9 +332,9 @@ if [[ -e /opt/ros/$ROS_DISTRO/setup.bash ]]; then
     env | grep -E "RMW|ROS" >> $host_ros_log_dir/record-system-stat.log
     echo "------------------" >> $host_ros_log_dir/record-system-stat.log
     if [ $verbose -eq 0 ]; then
-        ROS_LOG_DIR=$host_ros_log_dir ros2 launch cabot_debug record_system_stat.launch.xml >> $host_ros_log_dir/record-system-stat.log  2>&1 &
+        ROS_LOG_DIR=$host_ros_log_dir ros2 launch cabot_debug record_system_stat.launch.py >> $host_ros_log_dir/record-system-stat.log  2>&1 &
     else
-        ROS_LOG_DIR=$host_ros_log_dir ros2 launch cabot_debug record_system_stat.launch.xml &
+        ROS_LOG_DIR=$host_ros_log_dir ros2 launch cabot_debug record_system_stat.launch.py &
     fi
     blue "[$!] launch system stat $( echo "$(date +%s.%N) - $start" | bc -l )"
 fi

--- a/launch.sh
+++ b/launch.sh
@@ -19,6 +19,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+set -m
+
 start=`date +%s.%N`
 
 trap ctrl_c INT QUIT TERM
@@ -37,6 +40,11 @@ function ctrl_c() {
             launched=$((launched+1))
         done
 
+        red "kill -INT $dcpid"
+        kill -INT $dcpid
+        while kill -0 $dcpid 2> /dev/null; do
+            snore 1
+        done
         red "$dccom down"
         if [ $verbose -eq 1 ]; then
             $dccom down
@@ -45,6 +53,11 @@ function ctrl_c() {
         fi
     fi
     if [[ ! -z $bag_dccom ]]; then
+        red "kill -INT $bag_dcpid"
+        kill -INT $bag_dcpid
+        while kill -0 $bag_dcpid 2> /dev/null; do
+            snore 1
+        done
         red "$bag_dccom down"
         if [ $verbose -eq 1 ]; then
             $bag_dccom down
@@ -55,9 +68,6 @@ function ctrl_c() {
 
     for pid in ${pids[@]}; do
         signal=2
-        if [[ "${termpids[*]}" =~ "$pid" ]]; then
-            signal=15
-        fi
         if [ $verbose -eq 1 ]; then
             echo "killing $0 $pid"
             kill -s $signal $pid
@@ -221,7 +231,6 @@ shift $((OPTIND-1))
 
 ## private variables
 pids=()
-termpids=()
 
 ## check nvidia-smi
 if [ -z `which nvidia-smi` ]; then
@@ -301,7 +310,6 @@ fi
 if [[ $log_dmesg -eq 1 ]]; then
     blue "Logging dmesg"
     dmesg --time-format iso -w > $host_ros_log_dir/dmesg.log &
-    termpids+=($!)
     pids+=($!)
 fi
 
@@ -353,10 +361,11 @@ if [ $do_not_record -eq 0 ]; then
         export CABOT_DETECT_VERSION=2
     fi
     if [[ $separate_log -eq 1 ]]; then export CABOT_ROSBAG_SEPARATE_LOG=1; fi
-    com="bash -c \"setsid $bag_dccom --ansi never up --no-build --abort-on-container-exit\" > $host_ros_log_dir/docker-compose-bag.log &"
+    com="$bag_dccom --ansi never up --no-build --abort-on-container-exit > $host_ros_log_dir/docker-compose-bag.log &"
     blue $com
     eval $com
-    blue "[$!] recording ROS2 topics $( echo "$(date +%s.%N) - $start" | bc -l )"
+    bag_dcpid=($!)
+    blue "[$bag_dcpid] recording ROS2 topics $( echo "$(date +%s.%N) - $start" | bc -l )"
 else
     blue "do not record ROS2 topics"
 fi
@@ -389,9 +398,9 @@ if [ $reset_all_realsence -eq 1 ]; then
 fi
 
 if [ $verbose -eq 0 ]; then
-    com2="bash -c \"setsid $dccom --ansi never up --no-build --abort-on-container-exit\" > $host_ros_log_dir/docker-compose.log &"
+    com2="$dccom --ansi never up --no-build --abort-on-container-exit > $host_ros_log_dir/docker-compose.log &"
 else
-    com2="bash -c \"setsid $dccom up --no-build --abort-on-container-exit\" | tee $host_ros_log_dir/docker-compose.log &"
+    com2="$dccom up --no-build --abort-on-container-exit | tee $host_ros_log_dir/docker-compose.log &"
 fi
 if [ $verbose -eq 1 ]; then
     blue "$com2"
@@ -440,7 +449,6 @@ if [[ ! -z $CABOT_JETSON_CONFIG ]]; then
         blue "$com"
     fi
     eval $com
-    termpids+=($!)
     pids+=($!)
     blue "[$!] launch jetson $( echo "$(date +%s.%N) - $start" | bc -l )"
 fi
@@ -448,7 +456,6 @@ fi
 if [[ $screen_recording -eq 1 ]]; then
     blue "Recording screen"
     $scriptdir/record_screen.sh -d $host_ros_log_dir > /dev/null 2>&1 &
-    termpids+=($!)
     pids+=($!)
 fi
 


### PR DESCRIPTION
- use `set -m` to manage jobs in the bash shell, which enables to properly terminate ros2 launch processes
- update dependencies

### depends on

- https://github.com/CMU-cabot/cabot-navigation/pull/201
- https://github.com/CMU-cabot/cabot-people/pull/31
- https://github.com/CMU-cabot/cabot-drivers/pull/68