### PR TITLE
fix diagnostic launch error when mapping

### DIFF
--- a/docker-compose-mapping.yaml
+++ b/docker-compose-mapping.yaml
@@ -132,6 +132,7 @@ services:
       - ./cabot-navigation/cabot:/home/developer/diagnostic_ws/src/cabot
       - ./cabot-navigation/cabot_diagnostics:/home/developer/diagnostic_ws/src/cabot_diagnostics
       - ./cabot-navigation/cabot_ui:/home/developer/diagnostic_ws/src/cabot_ui
+      - ./cabot-navigation/cabot-common/cabot_common:/home/developer/diagnostic_ws/src/cabot_common
       - ./cabot-navigation/cabot-common/cabot_msgs:/home/developer/diagnostic_ws/src/cabot_msgs
       - ./cabot-navigation/script:/home/developer/diagnostic_ws/script
 # bridge - if DDS use shared memory


### PR DESCRIPTION
This pull request fixed following diagnostic launch error when mapping

```
diagnostic-1  | Asia/Tokyo
diagnostic-1  | [INFO] [launch]: All log files can be found below /home/developer/.ros/log/mapping_2025-06-17-20-43-25/2025-06-17-20-43-28-752156-AIS-K25-06-1
diagnostic-1  | [INFO] [launch]: Default logging verbosity is set to INFO
diagnostic-1  | [ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught multiple exceptions when trying to load file of format [py]:
diagnostic-1  |  - ModuleNotFoundError: No module named 'cabot_common'
diagnostic-1  |  - InvalidFrontendLaunchFileError: The launch file may have a syntax error, or its format is unknown
```

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>
