### PR TITLE
update cabot-navigation: fix clear transform buffer service call in mf_localization

### DIFF
--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: b0e3d5bbb342c7c8d42d2df327e8e78922bd1d09
+    version: dd6ddc451e2afb2607b427b76abc096d0dd115dd
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common


### PR DESCRIPTION
This PR reflects the change made by https://github.com/CMU-cabot/cabot-navigation/pull/225 to ros2-dev.