### PR TITLE
update cabot-navigation: move wireless_rss_localizer to mf_localization package

### DIFF
--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 5bcf8fde0c609846f7bd3b3dd800fa4c5681de9d
+    version: 9192254add7e2484f8214d588456fb14a5c7fa4c
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common


### PR DESCRIPTION
This pull request merge https://github.com/CMU-cabot/cabot-navigation/pull/237 to cabot