### PR TITLE
fix mapping-launch.sh to use different ROS_DOMAIN_ID during post-processing

### DIFF
--- a/mapping-launch.sh
+++ b/mapping-launch.sh
@@ -216,6 +216,16 @@ if [[ -n $post_process ]]; then
     if [[ $gazebo -eq 1 ]]; then
         export PROCESS_GAZEBO_MAPPING=1
     fi
+    # use ROS_DOMAIN_ID different from cabot-plugin
+    if grep -q "ROS_DOMAIN_ID=" .env; then
+      ROS_DOMAIN_ID=$(grep "ROS_DOMAIN_ID" .env | cut -d '=' -f2)
+      NEW_ROS_DOMAIN_ID=$(($ROS_DOMAIN_ID + 11))
+      echo "update ROS_DOMAIN_ID from $ROS_DOMAIN_ID to $NEW_ROS_DOMAIN_ID"
+      export ROS_DOMAIN_ID=$NEW_ROS_DOMAIN_ID
+    else
+      export ROS_DOMAIN_ID=11
+      echo "update ROS_DOMAIN_ID to $ROS_DOMAIN_ID"
+    fi
     blue "docker compose -f docker-compose-mapping-post-process.yaml run post-process"
     docker compose -f docker-compose-mapping-post-process.yaml run post-process
     exit


### PR DESCRIPTION
This pull request fixes an issue that post-process SLAM does not work as expected on a physical robot because it runs sensor driver nodes (e.g. cabot_can and ublox) that publish the same topics with rosbag play (e.g. imu, gnss_fix).
The issue can be solved by splitting ROS DOMAIN for real-time sensor data and rosbag play.