### PR TITLE
fix cabot-people docker build error

### DIFF
--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -178,7 +178,7 @@ repositories:
   cabot-people:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
-    version: 2af554268e564c30a3afcaef688f9f224849ba81
+    version: 8ce8ae113f61aadace3c8ddcd9cfd3480e312192
   cabot-people/cabot-base:
     type: git
     url: https://github.com/CMU-cabot/cabot-base


### PR DESCRIPTION
updated dependency-release.repos to use the latest version that fixed docker build error

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>