### PR TITLE
update cabot-navigation: suppress RTCM timeout warning when GNSS is not used for localization

### DIFF
--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 7cf2ab0a4939d36eac7d1a44265862dda3ec7975
+    version: 3c8ef7c4cf0f722a8eb55822760455fd7bb9d5fb
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common

--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 0c3c20d27e0a1af5ce2f47c7128e26b1a0214eb5
+    version: 7cf2ab0a4939d36eac7d1a44265862dda3ec7975
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common
@@ -158,7 +158,7 @@ repositories:
   cabot-navigation/docker/localization/ntrip_client:
     type: git
     url: https://github.com/cmu-cabot/ntrip_client.git
-    version: a8e841cd1b8764bb0ef760d360f78153e5d729da
+    version: 20d3650bef85ae63863dcbb9f53ff54e50ac0a3c
   cabot-navigation/docker/localization/ublox:
     type: git
     url: https://github.com/CMU-cabot/ublox.git


### PR DESCRIPTION
Update cabot-navigation and ntrip_client

- https://github.com/CMU-cabot/cabot-navigation/pull/256
- https://github.com/CMU-cabot/ntrip_client/commit/20d3650bef85ae63863dcbb9f53ff54e50ac0a3c