### PR TITLE
update cabot-navigation

### DIFF
--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -130,7 +130,7 @@ repositories:
   cabot-navigation:
     type: git
     url: https://github.com/CMU-cabot/cabot-navigation
-    version: 3c8ef7c4cf0f722a8eb55822760455fd7bb9d5fb
+    version: c36a59974e86e52f24afa160ee3f49382e7489bf
   cabot-navigation/cabot-common:
     type: git
     url: https://github.com/CMU-cabot/cabot-common


### PR DESCRIPTION
- restart navigation racing condition
- grid_map_ground_filter_node may stop because of Eigen invalid access

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>