### PR TITLE
update cabot-people, reduce docker image build time by specifying Jetson Orin architecture

### DIFF
--- a/dependency-release.repos
+++ b/dependency-release.repos
@@ -178,7 +178,7 @@ repositories:
   cabot-people:
     type: git
     url: https://github.com/CMU-cabot/cabot-people
-    version: 8ce8ae113f61aadace3c8ddcd9cfd3480e312192
+    version: 6060cb8d72a4cf8c81e24764eec94530957abdb8
   cabot-people/cabot-base:
     type: git
     url: https://github.com/CMU-cabot/cabot-base


### PR DESCRIPTION
DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>